### PR TITLE
fix(mergeable): Logging error when repository is not in the payload.

### DIFF
--- a/lib/mergeable.js
+++ b/lib/mergeable.js
@@ -1,6 +1,8 @@
 const createScheduler = require('probot-scheduler')
 const Handler = require('./handler')
 const flexExecutor = require('./flex')
+const _ = require('lodash')
+
 require('colors')
 
 class Mergeable {
@@ -40,9 +42,14 @@ class Mergeable {
   // version 2 of mergeable WIP as we refactor the code base.
   flex (robot) {
     robot.on('*', async context => {
-      context.log.info({Repo: context.payload.repository.full_name,
-        url: context.payload.repository.html_url,
-        private: context.payload.repository.private})
+      if (_.isUndefined(context.payload.repository)) {
+        context.log.warn('Unable to log repository name. There is no repository in the payload:')
+        context.log.warn(context.payload)
+      } else {
+        context.log.info({Repo: context.payload.repository.full_name,
+          url: context.payload.repository.html_url,
+          private: context.payload.repository.private})
+      }
       context.log.info({event: context.event, action: context.payload.action})
       flexExecutor(context)
     })


### PR DESCRIPTION
### Context
Logs are showing unhandled errors that occurs when trying to log info on `payload.repository.full_name`. Certain events do not have the `repository` property in the payload.

### Changes
Sanity check on the payload before logging repo info.

