### PR TITLE
refactor: move milestoned special case function to an interceptor -

### DIFF
--- a/__tests__/interceptors/milestoned.test.js
+++ b/__tests__/interceptors/milestoned.test.js
@@ -1,0 +1,41 @@
+const Milestoned = require('../../lib/interceptors/milestoned')
+const Helper = require('../../__fixtures__/helper')
+require('object-dot').extend()
+
+let milestoned = new Milestoned()
+test('#valid', () => {
+  let context = Helper.mockContext()
+  expect(milestoned.valid(context)).toBe(false)
+
+  context.event = 'issues'
+  expect(milestoned.valid(context)).toBe(false)
+
+  context.payload.issue = {}
+  context.payload.action = 'milestoned'
+  expect(milestoned.valid(context)).toBe(false)
+
+  context.payload.issue.pull_request = {}
+  expect(milestoned.valid(context)).toBe(true)
+
+  context.payload.action = 'demilestoned'
+  expect(milestoned.valid(context)).toBe(true)
+
+  context.payload.action = 'edited'
+  expect(milestoned.valid(context)).toBe(false)
+})
+
+test('#process', async () => {
+  let context = Helper.mockContext()
+  context.event = 'issues'
+  context.payload.action = 'milestoned'
+  Object.set(context, 'payload.issue.pull_request', {})
+  context.payload.issue.number = 12
+  context.github.pullRequests.get.mockReturnValue({ data: { number: 12 } })
+
+  // make sure we setup context correctly.
+  expect(milestoned.valid(context)).toBe(true)
+
+  context = await milestoned.process(context)
+  expect(context.payload.pull_request.number).toBe(12)
+  expect(context.event).toBe('pull_request')
+})

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -9,9 +9,6 @@ const executeMergeable = async (context, registry) => {
     registry = { validators: new Map(), actions: new Map() }
   }
 
-  // check for special Cases with anti-pattern
-  context = await checkAndProcessSpecialCases(context)
-
   // interceptors
   await interceptors(context)
 
@@ -136,20 +133,4 @@ const createPromises = (arrayToIterate, registryName, funcCall, context, registr
   return promises
 }
 
-// TODO: Move this to the interceptor registry.
-const checkAndProcessSpecialCases = async (context) => {
-  let processedContext = context
-  // check if issues.milestoned/demilestoned is actually from a pull_request
-  if (context.event === 'issues' && (context.payload.action === 'milestoned' || context.payload.action === 'demilestoned')) {
-    if (context.payload.issue.pull_request) {
-      // it is indeed an pull_request, fetch the pull_request
-      let res = await context.github.pullRequests.get(context.repo({number: context.payload.issue.number}))
-      res.data.action = context.payload.action
-      processedContext.event = 'pull_request'
-      processedContext.payload.pull_request = res.data
-      return processedContext
-    }
-  }
-  return context
-}
 module.exports = executeMergeable

--- a/lib/interceptors/index.js
+++ b/lib/interceptors/index.js
@@ -1,6 +1,7 @@
 const REGISTRY = [
-  new (require('./checkReRun'))() // eslint-disable-line
-]
+  new (require('./checkReRun'))(),
+  new (require('./milestoned'))()
+] // eslint-disable-line
 
 /**
  * Processes all the interceptors in the order of the registry array.

--- a/lib/interceptors/milestoned.js
+++ b/lib/interceptors/milestoned.js
@@ -1,0 +1,30 @@
+const Interceptor = require('./interceptor')
+
+/**
+ * Handles milestoned and demilestoned for Pull Requests.
+ */
+class Milestoned extends Interceptor {
+  async process (context) {
+    if (this.valid(context)) {
+      let res = await context.github.pullRequests.get(context.repo({number: context.payload.issue.number}))
+      res.data.action = context.payload.action
+      context.event = 'pull_request'
+      context.payload.pull_request = res.data
+    }
+    return context
+  }
+
+  /**
+   * @return true if issue has the action milestoned or demilestoned but is from a pull_request.
+   */
+  valid (context) {
+    // GH does not differentiate between issues and pulls for milestones. The only differentiator
+    // is the payload for issues containing a pull_request property.
+    return (context.event === 'issues' &&
+      (context.payload.action === 'milestoned' ||
+      context.payload.action === 'demilestoned')) &&
+      !!context.payload.issue.pull_request
+  }
+}
+
+module.exports = Milestoned


### PR DESCRIPTION
## Goals
- Clean up `flex` module

## Changes
- moved special case function catering to `demilestoned` and `milestoned` actions for issue event to an interceptor.
- Added tests for the interceptor
