### PR TITLE
feat: Update probot package

### DIFF
--- a/__fixtures__/helper.js
+++ b/__fixtures__/helper.js
@@ -48,7 +48,7 @@ module.exports = {
       github: {
         repos: {
           createStatus: () => {},
-          getContent: ({ path }) => {
+          getContents: ({ path }) => {
             return new Promise((resolve, reject) => {
               if (path === '.github/mergeable.yml') {
                 throwNotFound()
@@ -80,7 +80,7 @@ module.exports = {
           }
         },
         pullRequests: {
-          getFiles: () => {
+          listFiles: () => {
             if (_.isString(options.files && options.files[0])) {
               return {
                 data: options.files.map(
@@ -97,8 +97,12 @@ module.exports = {
               return { data: options.files && options.files }
             }
           },
-          getReviews: async () => {
-            return { data: (options.reviews) ? options.reviews : [] }
+          listReviews: {
+            endpoint: {
+              merge: async () => {
+                return { data: (options.reviews) ? options.reviews : [] }
+              }
+            }
           },
           get: jest.fn()
         },
@@ -106,18 +110,18 @@ module.exports = {
           return fn.then(cb)
         }),
         projects: {
-          getRepoProjects: () => {
+          listForRepo: () => {
             return { data: (options.repoProjects) ? options.repoProjects : [] }
           },
-          getProjectColumns: () => {
+          listColumns: () => {
             return { data: (options.projectColumns) ? options.projectColumns : [] }
           },
-          getProjectCards: () => {
+          listCards: () => {
             return { data: (options.projectCards) ? options.projectCards : [] }
           }
         },
         issues: {
-          getIssueLabels: () => {
+          listLabelsOnIssue: () => {
             return { data: (options.labels) ? options.labels : [] }
           },
           get: () => {
@@ -142,12 +146,12 @@ module.exports = {
   },
 
   mockConfigWithContext: (context, configString, options) => {
-    context.github.repos.getContent = () => {
+    context.github.repos.getContents = () => {
       return Promise.resolve({ data: {
         content: Buffer.from(configString).toString('base64') }
       })
     }
-    context.github.pullRequests.getFiles = () => {
+    context.github.pullRequests.listFiles = () => {
       return Promise.resolve({
         data: options && options.files ? options.files.map(file => ({ filename: file, status: 'modified' })) : []
       })

--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -207,7 +207,7 @@ describe('with version 1', () => {
       expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe('title regex')
       expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('label regex')
     })
-    expect(context.github.repos.getContent.mock.calls.length).toBe(1)
+    expect(context.github.repos.getContents.mock.calls.length).toBe(1)
   })
 
   test('that instanceWithContext returns the right Configuration (pull_requests)', async () => {
@@ -224,7 +224,7 @@ describe('with version 1', () => {
       expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe('title pull regex')
       expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('label pull regex')
     })
-    expect(context.github.repos.getContent.mock.calls.length).toBe(1)
+    expect(context.github.repos.getContents.mock.calls.length).toBe(1)
   })
 
   test('that instanceWithContext returns the right Configuration (issues)', async () => {
@@ -241,7 +241,7 @@ describe('with version 1', () => {
       expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe('title issue regex')
       expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('label issue regex')
     })
-    expect(context.github.repos.getContent.mock.calls.length).toBe(1)
+    expect(context.github.repos.getContents.mock.calls.length).toBe(1)
   })
 
   test('that instanceWithContext loads the configuration for stale correctly when specified for pull_requests and issues separately', async () => {
@@ -318,7 +318,7 @@ describe('with version 1', () => {
       },
       github: {
         repos: {
-          getContent: jest.fn().mockReturnValue(
+          getContents: jest.fn().mockReturnValue(
             Promise.reject(
               new HttpError(
                 '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/repos/contents/#get-contents"}',
@@ -339,7 +339,7 @@ describe('with version 1', () => {
       /* global fail */
       fail('Should handle error: ' + err)
     })
-    expect(context.github.repos.getContent.mock.calls.length).toBe(1)
+    expect(context.github.repos.getContents.mock.calls.length).toBe(1)
   })
 
   test('that if pass, fail or error is undefined in v2 config, the config will not break', async () => {
@@ -374,14 +374,14 @@ const createMockGhConfig = (json, prConfig, options) => {
     },
     github: {
       repos: {
-        getContent: jest.fn(({ref}) => {
+        getContents: jest.fn(({ref}) => {
           return Promise.resolve({
             data: { content: ref ? Buffer.from(prConfig).toString('base64') : Buffer.from(json).toString('base64') }
           })
         })
       },
       pullRequests: {
-        getFiles: () => {
+        listFiles: () => {
           return { data: options.files }
         }
       }

--- a/__tests__/validators/approvals.test.js
+++ b/__tests__/validators/approvals.test.js
@@ -429,12 +429,12 @@ test('that ownersEnabled will call fetch OWNERS file', async () => {
   let commitDiffs = createCommitDiffs(['first/second/third/dir/test.go'])
 
   const context = createMockContext(0, [], codeowner, commitDiffs)
-  context.github.repos.getContent = jest.fn().mockReturnValue(new Promise((resolve) => resolve({ data: {
+  context.github.repos.getContents = jest.fn().mockReturnValue(new Promise((resolve) => resolve({ data: {
     content: codeowner
   }})))
 
   await approval.validate(context, settings)
-  expect(context.github.repos.getContent.mock.calls[0][0].path).toBe('.github/CODEOWNERS')
+  expect(context.github.repos.getContents.mock.calls[0][0].path).toBe('.github/CODEOWNERS')
 })
 
 test('that ownersDisabled will call NOT fetch OWNERS file', async () => {
@@ -447,13 +447,13 @@ test('that ownersDisabled will call NOT fetch OWNERS file', async () => {
   let commitDiffs = createCommitDiffs(['first/second/third/dir/test.go'])
 
   const context = createMockContext(0, [], codeowner, commitDiffs)
-  context.github.repos.getContent = jest.fn().mockReturnValue(
+  context.github.repos.getContents = jest.fn().mockReturnValue(
     new Promise((resolve) => resolve({ data: {
       content: codeowner
     }})))
 
   await approval.validate(context, settings)
-  expect(context.github.repos.getContent.mock.calls.length).toBe(0)
+  expect(context.github.repos.getContents.mock.calls.length).toBe(0)
 })
 
 const createCommitDiffs = (diffs) => {

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -1,9 +1,9 @@
 const { Action } = require('./action')
 const populateTemplate = require('./handlebars/populateTemplate')
 
-const createComment = async (context, number, body) => {
+const createComment = async (context, issueNumber, body) => {
   return context.github.issues.createComment(
-    context.repo({ number, body })
+    context.repo({ issue_number: issueNumber, body })
   )
 }
 

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -113,7 +113,7 @@ class Configuration {
 
     if (['pull_request', 'pull_request_review'].includes(context.event)) {
       // get modified file list
-      let result = await context.github.pullRequests.getFiles(context.repo({number: context.payload.pull_request.number}))
+      let result = await context.github.pullRequests.listFiles(context.repo({pull_number: context.payload.pull_request.number}))
       let modifiedFiles = result.data
         .filter(file => ['modified', 'added'].includes(file.status))
         .map(file => file.filename)
@@ -121,7 +121,7 @@ class Configuration {
       // check if config file is in that list
       if (modifiedFiles.includes(Configuration.FILE_NAME)) {
         // if yes return, return below else do nothing
-        return github.repos.getContent({
+        return github.repos.getContents({
           owner: repo.owner,
           repo: repo.repo,
           path: Configuration.FILE_NAME,
@@ -130,7 +130,7 @@ class Configuration {
       }
     }
 
-    return github.repos.getContent({
+    return github.repos.getContents({
       owner: repo.owner,
       repo: repo.repo,
       path: Configuration.FILE_NAME

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -23,8 +23,8 @@ class Approvals extends Validator {
 
   async validate (context, validationSettings) {
     let reviews = await context.github.paginate(
-      context.github.pullRequests.getReviews(
-        context.repo({ number: this.getPayload(context).number })
+      context.github.pullRequests.listReviews.endpoint.merge(
+        context.repo({ pull_number: this.getPayload(context).number })
       ),
       res => res.data
     )

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -30,7 +30,7 @@ class Dependent extends Validator {
     const DEFUALT_SUCCESS_MESSAGE = 'All the Dependents files are present!'
 
     // fetch the file list
-    let result = await context.github.pullRequests.getFiles(context.repo({number: this.getPayload(context).number}))
+    let result = await context.github.pullRequests.listFiles(context.repo({pull_number: this.getPayload(context).number}))
     let modifiedFiles = result.data
       .filter(file => file.status === 'modified' || file.status === 'added')
       .map(file => file.filename)

--- a/lib/validators/label.js
+++ b/lib/validators/label.js
@@ -21,8 +21,8 @@ class Label extends Validator {
   }
 
   async validate (context, validationSettings) {
-    let labels = await context.github.issues.getIssueLabels(
-      context.repo({ number: this.getPayload(context).number })
+    let labels = await context.github.issues.listLabelsOnIssue(
+      context.repo({ issue_number: this.getPayload(context).number })
     )
 
     return this.processOptions(

--- a/lib/validators/options_processor/owners.js
+++ b/lib/validators/options_processor/owners.js
@@ -43,12 +43,12 @@ const extractUserId = async (owners) => {
 }
 
 const retrieveCODEOWNER = async (context) => {
-  return context.github.repos.getContent(context.repo({
+  return context.github.repos.getContents(context.repo({
     path: OWNER_FILE_PATH
   })).then(res => {
     return Buffer.from(res.data.content, 'base64').toString()
   }).catch(error => {
-    if (error.code === 404) return null
+    if (error.status === 404) return null
     else throw error
   })
 }

--- a/lib/validators/project.js
+++ b/lib/validators/project.js
@@ -76,7 +76,7 @@ const extractIssueIdsFromCards = (pr, cards) => {
 }
 
 const getProjects = async (context) => {
-  const res = await context.github.projects.getRepoProjects(
+  const res = await context.github.projects.listForRepo(
     context.repo()
   )
 
@@ -88,10 +88,10 @@ const getProjectCards = async (context, projIds) => {
 
   // get all the project columns
   for (let i = 0; i < projIds.length; i++) {
-    let res = await context.github.projects.getProjectColumns({project_id: projIds[i]})
+    let res = await context.github.projects.listColumns({project_id: projIds[i]})
     const columnIds = res.data.map(project => project.id)
 
-    res = await Promise.all(columnIds.map(id => context.github.projects.getProjectCards({column_id: id})))
+    res = await Promise.all(columnIds.map(id => context.github.projects.listCards({column_id: id})))
     res.forEach(card => {
       cards = cards.concat(card.data)
     })

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -30,12 +30,12 @@ class Size extends Validator {
 
     const payload = this.getPayload(context)
     const filesToIgnore = validationSettings.ignore || []
-    const getFilesResult = await context.github.pullRequests.getFiles(
-      context.repo({number: payload.number})
+    const listFilesResult = await context.github.pullRequests.listFiles(
+      context.repo({pull_number: payload.number})
     )
 
     // Possible file statuses: addded, modified, removed.
-    const modifiedFiles = getFilesResult.data
+    const modifiedFiles = listFilesResult.data
       .filter(file => !filesToIgnore.includes(file.filename))
       .filter(file => file.status === 'modified' || file.status === 'added')
       .map(

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.10",
     "node-fetch": "^2.1.2",
-    "probot": "^6.2.0",
-    "probot-scheduler": "^1.1.0",
+    "probot": "^9.2.5",
+    "probot-scheduler": "^2.0.0-beta.1",
     "colors": "^1.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Update the 'probot' npm package to the latest version.

This requires a number of small changes to deprecated methods in the github
context API. A couple of these were breaking, but most were just
deprecation warnings.

The main motivation for this was to fix a bug where the PRIVATE_KEY
environment variable was not being correctly recognised if it was base64
encoded, thus preventing deployment of the bot. base64-encoded keys are
supported in later versions of the probot lib:

https://probot.github.io/docs/configuration/

Support for this was added in 7.1.0:

https://github.com/probot/probot/pull/624