### PR TITLE
fix: check text display undefined in details when validation passes.

### DIFF
--- a/__tests__/actions/checks.test.js
+++ b/__tests__/actions/checks.test.js
@@ -18,8 +18,8 @@ test('check that checks created when doPostAction is called with proper paramete
 })
 
 test('that afterValidate is called with properly and output is correct', async () => {
-  const context = createMockContext()
   const checks = new Checks()
+  const context = createMockContext()
   const result = {
     status: 'pass',
     validations: [{

--- a/__tests__/actions/checks.test.js
+++ b/__tests__/actions/checks.test.js
@@ -18,9 +18,9 @@ test('check that checks created when doPostAction is called with proper paramete
 })
 
 test('that afterValidate is called with properly and output is correct', async () => {
-  const checks = new Checks()
   const context = createMockContext()
-  const result = {
+  let checks = new Checks()
+  let result = {
     status: 'pass',
     validations: [{
       status: 'pass',
@@ -45,6 +45,38 @@ test('that afterValidate is called with properly and output is correct', async (
   expect(context.github.checks.update.mock.calls.length).toBe(1)
   expect(output.summary).toBe('This is the summary')
   expect(output.title).toBe('Your run has returned the following status: pass')
+  expect(MetaData.exists(output.text)).toBe(false)
+})
+
+test('that afterValidate is correct when validation fails', async () => {
+  const context = createMockContext()
+  let checks = new Checks()
+  let result = {
+    status: 'fail',
+    validations: [{
+      status: 'fail',
+      name: 'Label'
+    }]
+  }
+  const settings = {
+    payload: {
+      title: `Your run has returned the following status: {{status}}`,
+      summary: 'This is the summary',
+      text: 'Errors occured.'
+    }
+  }
+
+  checks.checkRunResult = {
+    data: {
+      id: '4'
+    }
+  }
+
+  await checks.afterValidate(context, settings, result)
+  let output = context.github.checks.update.mock.calls[0][0].output
+  expect(context.github.checks.update.mock.calls.length).toBe(1)
+  expect(output.summary).toBe('This is the summary')
+  expect(output.title).toBe('Your run has returned the following status: fail')
   expect(MetaData.exists(output.text)).toBe(true)
 })
 

--- a/__tests__/actions/checks.test.js
+++ b/__tests__/actions/checks.test.js
@@ -19,8 +19,8 @@ test('check that checks created when doPostAction is called with proper paramete
 
 test('that afterValidate is called with properly and output is correct', async () => {
   const context = createMockContext()
-  let checks = new Checks()
-  let result = {
+  const checks = new Checks()
+  const result = {
     status: 'pass',
     validations: [{
       status: 'pass',
@@ -49,9 +49,9 @@ test('that afterValidate is called with properly and output is correct', async (
 })
 
 test('that afterValidate is correct when validation fails', async () => {
+  const checks = new Checks()
   const context = createMockContext()
-  let checks = new Checks()
-  let result = {
+  const result = {
     status: 'fail',
     validations: [{
       status: 'fail',

--- a/__tests__/metaData.test.js
+++ b/__tests__/metaData.test.js
@@ -30,4 +30,5 @@ test('#exists', () => {
   expect(MetaData.exists(dataText)).toBe(true)
   expect(MetaData.exists('abc <!-- #mergeable-data')).toBe(false)
   expect(MetaData.exists('abc #mergeable-data -->')).toBe(false)
+  expect(MetaData.exists(undefined)).toBe(false)
 })

--- a/lib/actions/checks.js
+++ b/lib/actions/checks.js
@@ -98,11 +98,14 @@ class Checks extends Action {
 
   async afterValidate (context, settings, results) {
     let payload = this.populatePayloadWithResult(settings.payload, results)
-    payload.text += MetaData.serialize({
-      id: this.checkRunResult.data.id,
-      event: context.event,
-      action: context.payload.action
-    })
+
+    if (payload.text !== undefined) {
+      payload.text += MetaData.serialize({
+        id: this.checkRunResult.data.id,
+        event: context.event,
+        action: context.payload.action
+      })
+    }
 
     await updateChecks(
       context,

--- a/lib/metaData.js
+++ b/lib/metaData.js
@@ -23,7 +23,7 @@ class MetaData {
    * @return true if meta data exists in a string.
    */
   static exists (text) {
-    return (text.indexOf(DATA_START) !== -1 && text.indexOf(DATA_END) !== -1)
+    return (text !== undefined && text.indexOf(DATA_START) !== -1 && text.indexOf(DATA_END) !== -1)
   }
 
   /**


### PR DESCRIPTION
## Goal
Fixes a bug where `undefined` is being displayed in the detail section of the checks when validation passes.

## Changes
- Only set metadata when check payload text exists. Text only exists when validation fails and metadata is only needed during this time.
- Update `MetaData.exists` to support undefined parameter.

## Details
### Before Fix
![image](https://user-images.githubusercontent.com/359064/56394290-ad0c8b00-61eb-11e9-874c-c58a5dc6c470.png)

### After Fix
![image](https://user-images.githubusercontent.com/359064/56394311-bdbd0100-61eb-11e9-826f-81b3af1a02b8.png)

