### PR TITLE
docs: Need read permissions to repo projects for private repos.

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -20,6 +20,7 @@ The [Probot deployment guide](https://probot.github.io/docs/deployment/) describ
 - Single File - **Read-only**
   - Path: `.github/mergeable.yml`
 - Repository Contents - **Read-Only**
+- Repository projects - **Read-Only**
 
 **And subscription to the following events:**
 - [x] Pull request


### PR DESCRIPTION
## Goal
Clarify project permissions.

## Changes
Add Repository Project permissions to list of Read-Only access setting.