### PR TITLE
refactor: Use the mergeable context instead to invoke the workflow.

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,0 +1,19 @@
+/**
+ * The Mergeable context is a wrapper and extension of the probot context with some convenience
+ * methods (in the future).
+ */
+class Context {
+  constructor (context) {
+    this.probotContext = context
+    this.event = context.event
+    this.payload = context.payload
+    this.github = context.github
+    this.log = context.log
+  }
+
+  repo (obj) {
+    return this.probotContext.repo(obj)
+  }
+}
+
+module.exports = Context

--- a/lib/mergeable.js
+++ b/lib/mergeable.js
@@ -1,5 +1,6 @@
 const createScheduler = require('probot-scheduler')
 const flexExecutor = require('./flex')
+const Context = require('./context')
 const _ = require('lodash')
 
 require('colors')
@@ -35,7 +36,8 @@ class Mergeable {
 
   // version 2 of mergeable.
   flex (robot) {
-    robot.on('*', async context => {
+    robot.on('*', async pContext => {
+      let context = new Context(pContext)
       let log = context.log.child({name: 'mergeable'})
       if (_.isUndefined(context.payload.repository)) {
         log.warn('Unable to log repository name. There is no repository in the payload:')


### PR DESCRIPTION
## Goal
Give us flexibility and allows us to upgrade to Probot 9.x without breaking changes. In 9.x the property `event` becomes a getter only property. We intercept webhook events and update the event property according to scenarios for workflow execution purposes.

## Changes
- Introduce the Context class.
- Pass our own Context instance to the workflow. This will be the instance used by all of mergeable.

## Notes
Another PR for abstracting the way mergeable creates a logger will be opened separately.

