### PR TITLE
feat: defaults are only loaded when no configuration found

### DIFF
--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -1,4 +1,5 @@
 const Configuration = require('../../lib/configuration/configuration')
+
 const helper = require('../../__fixtures__/helper')
 
 describe('Loading bad configuration', () => {
@@ -173,24 +174,15 @@ describe('with version 1', () => {
     expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('label regex')
   })
 
-  test('that defaults load correctly when mergeable is null', () => {
-    let config = new Configuration(`mergeable:`)
-    let validate = config.settings[0].validate
-
-    expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe(Configuration.DEFAULTS.title)
-    expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe(Configuration.DEFAULTS.label)
-    expect(validate.find(e => e.do === 'stale')).toBeUndefined()
-  })
-
-  test('that defaults load correctly when mergeable has partial properties defined', () => {
+  test('that defaults are not injected when user defined configuration exists', () => {
     let config = new Configuration(`
       mergeable:
         approvals: 1
       `)
     let validate = config.settings[0].validate
     expect(validate.find(e => e.do === 'approvals').min.count).toBe(1)
-    expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe(Configuration.DEFAULTS.title)
-    expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe(Configuration.DEFAULTS.label)
+    expect(validate.find(e => e.do === 'title')).toBeUndefined()
+    expect(validate.find(e => e.do === 'label')).toBeUndefined()
   })
 
   test('that instanceWithContext returns the right Configuration', async () => {
@@ -330,15 +322,12 @@ describe('with version 1', () => {
       }
     }
 
-    Configuration.instanceWithContext(context).then(config => {
-      let validate = config.settings[0].validate
+    let config = await Configuration.instanceWithContext(context)
+    let validate = config.settings[0].validate
 
-      expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe(Configuration.DEFAULTS.title)
-      expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe(Configuration.DEFAULTS.label)
-    }).catch(err => {
-      /* global fail */
-      fail('Should handle error: ' + err)
-    })
+    expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe('^wip')
+    expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('work in progress|wip|do not merge')
+
     expect(context.github.repos.getContent.mock.calls.length).toBe(1)
   })
 

--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -198,6 +198,7 @@ describe('with version 1', () => {
       expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe('title regex')
       expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('label regex')
     })
+
     expect(context.github.repos.getContents.mock.calls.length).toBe(1)
   })
 
@@ -326,8 +327,6 @@ describe('with version 1', () => {
 
     expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe('^wip')
     expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('work in progress|wip|do not merge')
-
-    expect(context.github.repos.getContent.mock.calls.length).toBe(1)
   })
 
   test('that if pass, fail or error is undefined in v2 config, the config will not break', async () => {

--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -1,5 +1,4 @@
 const Configuration = require('../../lib/configuration/configuration')
-
 const helper = require('../../__fixtures__/helper')
 
 describe('Loading bad configuration', () => {

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -25,7 +25,6 @@ class Configuration {
       if (this.errors.size > 0) return
 
       const version = this.checkConfigVersion()
-      if (version === 1) this.loadDefaults()
 
       this.settings = (require(`./transformers/v${version}Config`).transform(this.settings))
       this.settings = this.settings.mergeable
@@ -95,18 +94,6 @@ class Configuration {
     }
   }
 
-  loadDefaults () {
-    let pullRequestOrIssuesSubOptionExists = false
-    if (this.settings.mergeable == null) this.settings.mergeable = {}
-    if (this.settings.mergeable.pull_requests || this.settings.mergeable.issues) pullRequestOrIssuesSubOptionExists = true
-
-    for (let key in Configuration.DEFAULTS) {
-      if (!pullRequestOrIssuesSubOptionExists && this.settings.mergeable[key] === undefined) {
-        this.settings.mergeable[key] = Configuration.DEFAULTS[key]
-      }
-    }
-  }
-
   static async fetchConfigFile (context) {
     let github = context.github
     let repo = context.repo()
@@ -155,8 +142,6 @@ class Configuration {
 
 Configuration.FILE_NAME = '.github/mergeable.yml'
 Configuration.DEFAULTS = {
-  label: 'work in progress|do not merge|experimental|proof of concept',
-  title: 'wip|dnm|exp|poc',
   stale: {
     message: 'There haven\'t been much activity here. This is stale. Is it still relevant? This is a friendly reminder to please resolve it. :-)'
   }

--- a/lib/configuration/lib/consts.js
+++ b/lib/configuration/lib/consts.js
@@ -92,12 +92,12 @@ Settings : {{{displaySettings details.settings}}}
   DEFAULT_PR_VALIDATE: [{
     do: 'title',
     must_exclude: {
-      regex: 'wip|dnm|exp|poc'
+      regex: '^wip'
     }
   }, {
     do: 'label',
     must_exclude: {
-      regex: 'work in progress|do not merge|experimental|proof of concept'
+      regex: 'work in progress|wip|do not merge'
     }
   }, {
     do: 'description',


### PR DESCRIPTION
## Goals
resolves #194 

## Changes
- Only set defaults when no configuration is found in the repos.
- Change the default title regex to be more precise. It makes more sense to only check for `wip` in the beginning of the title.
- Change the default label regex to only look for "work in progress" and "do not merge."