### PR TITLE
feat: Add option for requiring assignee approval

### DIFF
--- a/__tests__/validators/options_processor/assignees.test.js
+++ b/__tests__/validators/options_processor/assignees.test.js
@@ -1,0 +1,18 @@
+const Helper = require('../../../__fixtures__/helper')
+const assignees = require('../../../lib/validators/options_processor/assignees')
+
+test('that assignees are correctly retrieved', async () => {
+  let res = await assignees.process(createMockPR(), Helper.mockContext())
+  expect(res.length).toBe(1)
+  expect(res[0]).toBe('bob')
+})
+
+const createMockPR = () => {
+  return Helper.mockContext({
+    user: {
+      login: 'creator'
+    },
+    number: 1,
+    assignees: [{login: 'bob'}]
+  }).payload.pull_request
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,8 +109,9 @@ For convenience, wildcards can be used: `pull_request.*`, `issues.*`, `pull_requ
     count: 2 # Number of minimum reviewers. In this case 2.
     message: 'Custom message...'
   required:
-    reviewers: [ user1, user2 ]   # list of github usernames required to review
-    owners: true # accepts boolean. When true,  the file .github/CODEOWNER is read and owners made required reviewers
+    reviewers: [ user1, user2 ] # list of github usernames required to review
+    owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and owners made required reviewers
+    assignees: true # Optional boolean. When true, PR assignees are made required reviewers.
     message: 'Custom message...'
 ```
 

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -1,5 +1,6 @@
 const { Validator } = require('./validator')
 const Owner = require('./options_processor/owners')
+const Assignees = require('./options_processor/assignees')
 const _ = require('lodash')
 
 class Approvals extends Validator {
@@ -40,6 +41,9 @@ class Approvals extends Validator {
     const ownerList = (validationSettings && validationSettings.required && validationSettings.required.owners)
         ? await Owner.process(this.getPayload(context), context) : []
 
+    const assigneeList = (validationSettings && validationSettings.required && validationSettings.required.assignees)
+      ? await Assignees.process(this.getPayload(context), context) : []
+
     if (ownerList.length > 0) {
       // append it to the required reviewer list
       requiredReviewer = requiredReviewer.concat(ownerList)
@@ -48,8 +52,16 @@ class Approvals extends Validator {
       requiredReviewer = _.uniq(requiredReviewer)
     }
 
+    if (assigneeList.length > 0) {
+      // append it to the required reviewer list
+      requiredReviewer = requiredReviewer.concat(assigneeList)
+
+      // there could be duplicates between reviewer and assigneeList
+      requiredReviewer = _.uniq(requiredReviewer)
+    }
+
     if (requiredReviewer.length > 0) {
-      validationSettings = Object.assign({}, validationSettings, {required: { owners: ownerList, reviewers: requiredReviewer }})
+      validationSettings = Object.assign({}, validationSettings, {required: { owners: ownerList, assignees: assigneeList, reviewers: requiredReviewer }})
     }
 
     let approvedReviewers = findApprovedReviewers(reviews)

--- a/lib/validators/options_processor/assignees.js
+++ b/lib/validators/options_processor/assignees.js
@@ -1,0 +1,7 @@
+class Assignees {
+  static async process (payload, context) {
+    return payload.assignees.map(user => user.login)
+  }
+}
+
+module.exports = Assignees

--- a/lib/validators/options_processor/options/required.js
+++ b/lib/validators/options_processor/options/required.js
@@ -6,6 +6,7 @@ class Required {
 
     const reviewers = filter['reviewers'] ? filter['reviewers'] : []
     const owners = filter['owners'] ? filter['owners'] : []
+    const assignees = filter['assignees'] ? filter['assignees'] : []
     let description = filter['message']
 
     if (!Array.isArray(input)) {
@@ -18,8 +19,18 @@ class Required {
 
     const isMergeable = remainingRequired.size === 0
 
+    const requiredReviewers = Array.from(remainingRequired.values()).map(user => {
+      if (owners.includes(user)) {
+        return user + '(Code Owner) '
+      }
+      if (assignees.includes(user)) {
+        return user + '(Assignee) '
+      }
+      return user + ' '
+    })
+
     const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name}: all required reviewers have approved`
-    if (!description) description = `${validatorContext.name}: ${Array.from(remainingRequired.values()).map(user => owners.includes(user) ? user + '(Code Owner) ' : user + ' ')}required`
+    if (!description) description = `${validatorContext.name}: ${requiredReviewers}required`
 
     return {
       status: isMergeable ? 'pass' : 'fail',


### PR DESCRIPTION
Adds an option to the `approvals.required` config for specifying that all PR assignees are required to approve. When set to true, it automatically adds all assignees to the list of required approvers, similar to how the `owners` option works.
