### PR TITLE
feat: Support glob patterns in size validator

### DIFF
--- a/__tests__/validators/size.test.js
+++ b/__tests__/validators/size.test.js
@@ -95,6 +95,61 @@ describe('PR size validator', () => {
     expect(validation.validations[0].description).toBe('PR size is OK!')
   })
 
+  test('ignores glob patterns', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 15,
+          message: 'Too big!'
+        }
+      },
+      ignore: ['nested/one/*', 'nested/two/**']
+    }
+
+    let files = [
+      {
+        filename: 'not_too_big.js',
+        status: 'modified',
+        additions: 10,
+        deletions: 0,
+        changes: 10
+      },
+      {
+        filename: 'nested/one/big_file_1.js',
+        status: 'added',
+        additions: 30,
+        deletions: 0,
+        changes: 30
+      },
+      {
+        filename: 'nested/one/big_file_2.js',
+        status: 'added',
+        additions: 30,
+        deletions: 0,
+        changes: 30
+      },
+      {
+        filename: 'nested/two/three/big_file_3.js',
+        status: 'modified',
+        additions: 30,
+        deletions: 0,
+        changes: 30
+      }
+    ]
+
+    let validation = await size.validate(createMockContext(files), settings)
+    expect(validation.status).toBe('pass')
+    expect(validation.validations[0].description).toBe('PR size is OK!')
+
+    settings.ignore = ['**/big_file_*.js']
+
+    validation = await size.validate(createMockContext(files), settings)
+    expect(validation.status).toBe('pass')
+    expect(validation.validations[0].description).toBe('PR size is OK!')
+  })
+
   test('handles empty ignore args', async () => {
     const size = new Size()
     let settings = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -176,19 +176,28 @@ changed lines is below a certain amount using the `max` option:
 
 It also supports an `ignore` setting to allow excluding certain files from the
 total size (e.g. for ignoring automatically generated files that increase the
-size a lot):
+size a lot).
+
+This option supports glob patterns, so you can provide either the path to a
+specific file or ignore whole patterns:
 
 ```yml
   - do: size
-    ignore: ['package-lock.json']
+    ignore: ['package-lock.json', 'src/tests/__snapshots__/**', 'docs/*.md']
     lines:
       max:
         count: 500
         message: Change is very large. Should be under 500 lines of addtions and deletions.
 ```
 
+Note that the glob functionality is powered by the [minimatch] library. Please
+see their documentation for details on how glob patterns are handled and
+possible discrepancies with glob handling in other tools.
+
 The `size` validator currently excludes from the size count any files that were
 completely deleted in the PR.
+
+[minimatch]: https://github.com/isaacs/minimatch
 
 #### Supported events
 ```js
@@ -496,7 +505,7 @@ Validate pull requests for mergeability based on content and structure of your P
 <br>
 
 **Size**: Ensure that PRs don't exceed a certain size in terms of lines changed
-(excluding files specified with `ignore`).
+(excluding file patterns specified with `ignore`).
 
 <details><summary>🔖 See Recipe</summary>
   <p>
@@ -507,7 +516,7 @@ Validate pull requests for mergeability based on content and structure of your P
     - when: pull_request.*
       validate:
         - do: size
-          ignore: ['ignore_me.js']
+          ignore: ['ignore_me.js', 'ignore_this_directory/*', '**/ignore_this_prefix*.js']
           lines:
             max:
               count: 500

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -1,3 +1,5 @@
+const minimatch = require('minimatch')
+
 const { Validator } = require('./validator')
 const constructOutput = require('./options_processor/options/lib/constructOutput')
 const consolidateResult = require('./options_processor/options/lib/consolidateResults')
@@ -29,14 +31,14 @@ class Size extends Validator {
     const validatorContext = {name: VALIDATOR_NAME}
 
     const payload = this.getPayload(context)
-    const filesToIgnore = validationSettings.ignore || []
+    const patternsToIgnore = validationSettings.ignore || []
     const listFilesResult = await context.github.pullRequests.listFiles(
       context.repo({pull_number: payload.number})
     )
 
     // Possible file statuses: addded, modified, removed.
     const modifiedFiles = listFilesResult.data
-      .filter(file => !filesToIgnore.includes(file.filename))
+      .filter(file => !matchesIgnoredPatterns(file.filename, patternsToIgnore))
       .filter(file => file.status === 'modified' || file.status === 'added')
       .map(
         file => ({
@@ -91,5 +93,9 @@ class Size extends Validator {
     return consolidateResult([output], validatorContext)
   }
 }
+
+const matchesIgnoredPatterns = (filename, patternsToIgnore) => (
+  patternsToIgnore.some((ignorePattern) => minimatch(filename, ignorePattern))
+)
 
 module.exports = Size

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "node-fetch": "^2.1.2",
     "probot": "^9.2.5",
     "probot-scheduler": "^2.0.0-beta.1",
-    "colors": "^1.3.2"
+    "colors": "^1.3.2",
+    "minimatch": "^3.0.4"
   },
   "devDependencies": {
     "codecov": "^3.1.0",


### PR DESCRIPTION
The size validator 'ignore' option only allowed specifying absolute file
paths. This adds support for glob pattern matching to allow specifying
patterns to ignore.

This relies on the minimatch library (pulled in as a new dependency) to
perform the glob handling and conversion to regular expressions:

https://github.com/isaacs/minimatch

This addresses https://github.com/mergeability/mergeable/issues/217