### PR TITLE
fix: Fix the incorrect environment name

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,7 +11,7 @@ PRIVATE_KEY=
 PRIVATE_KEY_PATH=
 
 # Set this to the GitHub webhook secret configured for your app.
-SECRET_TOKEN=
+WEBHOOK_SECRET=
 
 # Set this to the webhook URL created with `smee`.
 WEBHOOK_PROXY_URL=


### PR DESCRIPTION
According to the probot documentation at
https://probot.github.io/docs/configuration/, the expected variable name is
`WEBHOOK_SECRET` and not `SECRET_TOKEN`