### PR TITLE
fix: FetchConfigFile from forked PR

### DIFF
--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -355,7 +355,8 @@ const createMockGhConfig = (json, prConfig, options) => {
       pull_request: {
         number: 1,
         head: {
-          ref: 1
+          ref: 1,
+          sha: 1
         }
       }
     },

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -112,7 +112,7 @@ class Configuration {
           owner: repo.owner,
           repo: repo.repo,
           path: Configuration.FILE_NAME,
-          ref: context.payload.pull_request.head.ref
+          ref: context.payload.pull_request.head.sha
         })
       }
     }


### PR DESCRIPTION
FetchConfigFile would fail when trying to fetch a modified config from a PR living on a fork. It would try to use the pull_request's ref (aka the branch name) on the original repository, which would fail since said branch does not exist (github would return a 404).

To give a practical example: In SunriseOS, I made a PR that modified the configuration from my fork. Mergeable would attempt fetching https://api.github.com/repos/sunriseos/SunriseOS/contents/.github/mergeable.yml?ref=mergeable-v2 , which 404s.

There are two valid URLs we can try using:

- Using the PR's repo name: https://api.github.com/repos/roblabla/KFS/contents/.github/mergeable.yml?ref=mergeable-v2
- Using the PR's head SHA: https://api.github.com/repos/sunriseos/SunriseOS/contents/.github/mergeable.yml?ref=c333c15eb4215acfac73d263a5c2c33b3d7b8b6e

I went with that second solution.