### PR TITLE
feat: seperate PR size types: additions, deletions and total

### DIFF
--- a/__tests__/validators/size.test.js
+++ b/__tests__/validators/size.test.js
@@ -49,8 +49,11 @@ describe('PR size validator', () => {
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('Too big!')
+    expect(validation.validations[0].status).toBe('fail')
     expect(validation.validations[1].description).toBe('Too big!')
+    expect(validation.validations[1].status).toBe('fail')
     expect(validation.validations[2].description).toBe('Too big!')
+    expect(validation.validations[2].status).toBe('fail')
   })
 
   test('passes when changes equal to count', async () => {
@@ -76,8 +79,11 @@ describe('PR size validator', () => {
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[0].status).toBe('pass')
     expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[1].status).toBe('pass')
     expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
+    expect(validation.validations[2].status).toBe('pass')
   })
 
   test('partial fails and passing when part of PR is within count', async () => {
@@ -103,8 +109,11 @@ describe('PR size validator', () => {
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[0].status).toBe('pass')
     expect(validation.validations[1].description).toBe('Too big!')
+    expect(validation.validations[1].status).toBe('fail')
     expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
+    expect(validation.validations[2].status).toBe('pass')
   })
 
   test('ignores specified files', async () => {
@@ -131,8 +140,11 @@ describe('PR size validator', () => {
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[0].status).toBe('pass')
     expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[1].status).toBe('pass')
     expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
+    expect(validation.validations[2].status).toBe('pass')
   })
 
   test('ignores glob patterns', async () => {
@@ -190,16 +202,22 @@ describe('PR size validator', () => {
     let validation = await size.validate(createMockContext(files), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[0].status).toBe('pass')
     expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[1].status).toBe('pass')
     expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
+    expect(validation.validations[2].status).toBe('pass')
 
     settings.ignore = ['**/big_file_*.js']
 
     validation = await size.validate(createMockContext(files), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[0].status).toBe('pass')
     expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[1].status).toBe('pass')
     expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
+    expect(validation.validations[2].status).toBe('pass')
   })
 
   test('handles empty ignore args', async () => {
@@ -226,8 +244,11 @@ describe('PR size validator', () => {
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('Too big!')
+    expect(validation.validations[0].status).toBe('fail')
     expect(validation.validations[1].description).toBe('Too big!')
+    expect(validation.validations[1].status).toBe('fail')
     expect(validation.validations[2].description).toBe('Too big!')
+    expect(validation.validations[2].status).toBe('fail')
 
     settings = {
       do: 'size',
@@ -251,8 +272,11 @@ describe('PR size validator', () => {
     validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[0].status).toBe('pass')
     expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[1].status).toBe('pass')
     expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
+    expect(validation.validations[2].status).toBe('pass')
   })
 })
 

--- a/__tests__/validators/size.test.js
+++ b/__tests__/validators/size.test.js
@@ -26,12 +26,20 @@ describe('PR size validator', () => {
     }
   ]
 
-  test('fails when size above max', async () => {
+  test('fails when size of changes is above count', async () => {
     const size = new Size()
     const settings = {
       do: 'size',
       lines: {
-        max: {
+        additions: {
+          count: 10,
+          message: 'Too big!'
+        },
+        deletions: {
+          count: 5,
+          message: 'Too big!'
+        },
+        total: {
           count: 10,
           message: 'Too big!'
         }
@@ -41,31 +49,24 @@ describe('PR size validator', () => {
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('Too big!')
+    expect(validation.validations[1].description).toBe('Too big!')
+    expect(validation.validations[2].description).toBe('Too big!')
   })
 
-  test('passes when changes below max', async () => {
+  test('passes when changes equal to count', async () => {
     const size = new Size()
     const settings = {
       do: 'size',
       lines: {
-        max: {
-          count: 50,
+        additions: {
+          count: 13,
           message: 'Too big!'
-        }
-      }
-    }
-
-    let validation = await size.validate(createMockContext(FILES), settings)
-    expect(validation.status).toBe('pass')
-    expect(validation.validations[0].description).toBe('PR size is OK!')
-  })
-
-  test('passes when changes equal to max', async () => {
-    const size = new Size()
-    const settings = {
-      do: 'size',
-      lines: {
-        max: {
+        },
+        deletions: {
+          count: 7,
+          message: 'Too big!'
+        },
+        total: {
           count: 20,
           message: 'Too big!'
         }
@@ -74,7 +75,9 @@ describe('PR size validator', () => {
 
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
-    expect(validation.validations[0].description).toBe('PR size is OK!')
+    expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
   })
 
   test('ignores specified files', async () => {
@@ -82,7 +85,15 @@ describe('PR size validator', () => {
     const settings = {
       do: 'size',
       lines: {
-        max: {
+        additions: {
+          count: 10,
+          message: 'Too big!'
+        },
+        deletions: {
+          count: 5,
+          message: 'Too big!'
+        },
+        total: {
           count: 15,
           message: 'Too big!'
         }
@@ -92,7 +103,9 @@ describe('PR size validator', () => {
 
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
-    expect(validation.validations[0].description).toBe('PR size is OK!')
+    expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
   })
 
   test('ignores glob patterns', async () => {
@@ -100,7 +113,15 @@ describe('PR size validator', () => {
     const settings = {
       do: 'size',
       lines: {
-        max: {
+        additions: {
+          count: 10,
+          message: 'Too big!'
+        },
+        deletions: {
+          count: 5,
+          message: 'Too big!'
+        },
+        total: {
           count: 15,
           message: 'Too big!'
         }
@@ -141,13 +162,17 @@ describe('PR size validator', () => {
 
     let validation = await size.validate(createMockContext(files), settings)
     expect(validation.status).toBe('pass')
-    expect(validation.validations[0].description).toBe('PR size is OK!')
+    expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
 
     settings.ignore = ['**/big_file_*.js']
 
     validation = await size.validate(createMockContext(files), settings)
     expect(validation.status).toBe('pass')
-    expect(validation.validations[0].description).toBe('PR size is OK!')
+    expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
   })
 
   test('handles empty ignore args', async () => {
@@ -155,7 +180,15 @@ describe('PR size validator', () => {
     let settings = {
       do: 'size',
       lines: {
-        max: {
+        additions: {
+          count: 10,
+          message: 'Too big!'
+        },
+        deletions: {
+          count: 5,
+          message: 'Too big!'
+        },
+        total: {
           count: 15,
           message: 'Too big!'
         }
@@ -166,12 +199,22 @@ describe('PR size validator', () => {
     let validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('Too big!')
+    expect(validation.validations[1].description).toBe('Too big!')
+    expect(validation.validations[2].description).toBe('Too big!')
 
     settings = {
       do: 'size',
       lines: {
-        max: {
-          count: 50,
+        additions: {
+          count: 13,
+          message: 'Too big!'
+        },
+        deletions: {
+          count: 7,
+          message: 'Too big!'
+        },
+        total: {
+          count: 20,
           message: 'Too big!'
         }
       },
@@ -180,7 +223,9 @@ describe('PR size validator', () => {
 
     validation = await size.validate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
-    expect(validation.validations[0].description).toBe('PR size is OK!')
+    expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[1].description).toBe('PR size for deletions is OK!')
+    expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
   })
 })
 

--- a/__tests__/validators/size.test.js
+++ b/__tests__/validators/size.test.js
@@ -80,6 +80,33 @@ describe('PR size validator', () => {
     expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
   })
 
+  test('partial fails and passing when part of PR is within count', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        additions: {
+          count: 13,
+          message: 'Too big!'
+        },
+        deletions: {
+          count: 5,
+          message: 'Too big!'
+        },
+        total: {
+          count: 20,
+          message: 'Too big!'
+        }
+      }
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('fail')
+    expect(validation.validations[0].description).toBe('PR size for additions is OK!')
+    expect(validation.validations[1].description).toBe('Too big!')
+    expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
+  })
+
   test('ignores specified files', async () => {
     const size = new Size()
     const settings = {

--- a/__tests__/validators/size.test.js
+++ b/__tests__/validators/size.test.js
@@ -26,6 +26,65 @@ describe('PR size validator', () => {
     }
   ]
 
+  test('errors if both max and total are passed', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 10,
+          message: 'Too big!'
+        },
+        total: {
+          count: 10,
+          message: 'Too big!'
+        }
+      }
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('error')
+    expect(validation.validations[0].description).toBe('Options max and total cannot be used together. Please choose one')
+    expect(validation.validations[0].status).toBe('error')
+  })
+
+  test('backwards compatibility test for max and total', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 10,
+          message: 'Too big!'
+        }
+      }
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('fail')
+    expect(validation.validations[0].description).toBe('Too big!')
+    expect(validation.validations[0].status).toBe('fail')
+  })
+
+  test('errors if invalid configurations is passed', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        something: {
+          count: 10,
+          message: 'Too big!'
+        }
+      }
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    const ERROR_MESSAGE = `Failed to validate because the 'lines' or 'max / total', 'additions' or 'deletions' option is missing. Please check the documentation.`
+    expect(validation.status).toBe('error')
+    expect(validation.validations[0].description).toBe(ERROR_MESSAGE)
+    expect(validation.validations[0].status).toBe('error')
+  })
+
   test('fails when size of changes is above count', async () => {
     const size = new Size()
     const settings = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,15 +163,20 @@ The above will validate that both the files `package-lock.json` and `yarn.lock` 
 ### Size
 
 `size` validates that the size of changes in the pull request conform to a
-specified limit. Currently this only lets you validate that the total number of
-changed lines is below a certain amount using the `max` option:
+specified limit. We can pass in three options: `total`, `additions` or `deletions`. Each of this take in a `count` and `message`.
 
 ```yml
   - do: size
     lines:
-      max:
+      total:
         count: 500
-        message: Change is very large. Should be under 500 lines of addtions and deletions.
+        message: Change is very large. Should be under 500 lines of additions and deletions.
+      additions:
+        count: 250
+        message: Change is very large. Should be under 250 lines of additions 
+      deletions:
+        count: 500
+        message: Change is very large. Should be under 250 lines of deletions.
 ```
 
 It also supports an `ignore` setting to allow excluding certain files from the
@@ -185,9 +190,9 @@ specific file or ignore whole patterns:
   - do: size
     ignore: ['package-lock.json', 'src/tests/__snapshots__/**', 'docs/*.md']
     lines:
-      max:
+      total:
         count: 500
-        message: Change is very large. Should be under 500 lines of addtions and deletions.
+        message: Change is very large. Should be under 500 lines of additions and deletions
 ```
 
 Note that the glob functionality is powered by the [minimatch] library. Please

--- a/docs/README.md
+++ b/docs/README.md
@@ -179,6 +179,15 @@ specified limit. We can pass in three options: `total`, `additions` or `deletion
         message: Change is very large. Should be under 250 lines of deletions.
 ```
 
+`max` is an alias for `total`, so the below configuration is still valid. 
+```yml
+ - do: size
+    lines:
+      max:
+        count: 500
+        message: Change is very large. Should be under 500 lines of additions and deletions.
+```
+
 It also supports an `ignore` setting to allow excluding certain files from the
 total size (e.g. for ignoring automatically generated files that increase the
 size a lot).

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -75,55 +75,67 @@ class Size extends Validator {
       )
     }
 
-    let isMergeable = {
-      additions: true,
-      deletions: true,
-      total: true
-    }
-
-    let messages = []
-    let description, defaultFailMessage
+    let output = []
 
     if (!!validationSettings.lines.additions && !!validationSettings.lines.additions.count) {
-      isMergeable.additions = additions <= validationSettings.lines.additions.count
-      defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.additions.count} additions`
-      description = isMergeable.additions
+      const isMergeable = additions <= validationSettings.lines.additions.count
+      const defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.additions.count} additions`
+      const description = isMergeable
       ? 'PR size for additions is OK!'
       : validationSettings.lines.additions.message || defaultFailMessage
-      messages.push(description)
-    }
 
-    if (!!validationSettings.lines.deletions && !!validationSettings.lines.deletions.count) {
-      isMergeable.deletions = deletions <= validationSettings.lines.deletions.count
-      defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.deletions.count} deletions`
-      description = isMergeable.deletions
-        ? 'PR size for deletions is OK!'
-        : validationSettings.lines.deletions.message || defaultFailMessage
-      messages.push(description)
-    }
-
-    if (!!validationSettings.lines.total && !!validationSettings.lines.total.count) {
-      isMergeable.total = totalChanges <= validationSettings.lines.total.count
-      defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.total.count} total additions + deletions`
-      description = isMergeable.total
-        ? 'PR size for total additions + deletions is OK!'
-        : validationSettings.lines.total.message || defaultFailMessage
-      messages.push(description)
-    }
-
-    const output = messages.map(message => {
       const result = {
-        status: isMergeable.total && isMergeable.additions && isMergeable.deletions ? 'pass' : 'fail',
-        description: message
+        status: isMergeable ? 'pass' : 'fail',
+        description: description
       }
 
-      return constructOutput(
+      output.push(constructOutput(
         validatorContext,
         inputMessage,
         validationSettings,
         result
-      )
-    })
+      ))
+    }
+
+    if (!!validationSettings.lines.deletions && !!validationSettings.lines.deletions.count) {
+      const isMergeable = deletions <= validationSettings.lines.deletions.count
+      const defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.deletions.count} deletions`
+      const description = isMergeable
+        ? 'PR size for deletions is OK!'
+        : validationSettings.lines.deletions.message || defaultFailMessage
+
+      const result = {
+        status: isMergeable ? 'pass' : 'fail',
+        description: description
+      }
+
+      output.push(constructOutput(
+          validatorContext,
+          inputMessage,
+          validationSettings,
+          result
+        ))
+    }
+
+    if (!!validationSettings.lines.total && !!validationSettings.lines.total.count) {
+      const isMergeable = totalChanges <= validationSettings.lines.total.count
+      const defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.total.count} total additions + deletions`
+      const description = isMergeable
+        ? 'PR size for total additions + deletions is OK!'
+        : validationSettings.lines.total.message || defaultFailMessage
+
+      const result = {
+        status: isMergeable ? 'pass' : 'fail',
+        description: description
+      }
+
+      output.push(constructOutput(
+          validatorContext,
+          inputMessage,
+          validationSettings,
+          result
+        ))
+    }
 
     return consolidateResult(output, validatorContext)
   }

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -1,5 +1,5 @@
 const minimatch = require('minimatch')
-const _ = require('lodash')
+const { pick, mapKeys, isUndefined } = require('lodash')
 
 const { Validator } = require('./validator')
 const constructOutput = require('./options_processor/options/lib/constructOutput')
@@ -80,9 +80,9 @@ class Size extends Validator {
     }
 
     // lets get available keys. must be either total, max, additions or deletions
-    const prSize = _.pick(validationSettings.lines, ['additions', 'deletions', 'total', 'max'])
+    const prSize = pick(validationSettings.lines, ['additions', 'deletions', 'total', 'max'])
 
-    if (!_.isUndefined(prSize.max) && !_.isUndefined(prSize.total)) {
+    if (!isUndefined(prSize.max) && !isUndefined(prSize.total)) {
       return consolidateResult(
         [
           constructErrorOutput(
@@ -102,7 +102,7 @@ class Size extends Validator {
     }
     let output = []
 
-    _.mapKeys(prSize, (value, key) => {
+    mapKeys(prSize, (value, key) => {
       const isMergeable = prSizeChanges[key] <= value.count
       const message = key === 'total' ? 'total additions + deletions' : key
       const defaultFailMessage = `PR is too large. Should be under ${value.count} ${message}`

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -61,7 +61,7 @@ class Size extends Validator {
 
     const inputMessage = `${totalChanges} (${additions} additions, ${deletions} deletions)`
 
-    if (!validationSettings.lines || !validationSettings.lines.max) {
+    if (!validationSettings.lines) {
       return consolidateResult(
         [
           constructErrorOutput(
@@ -75,22 +75,52 @@ class Size extends Validator {
       )
     }
 
-    const isMergeable = totalChanges <= validationSettings.lines.max.count
-    const defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.max.count} total additions + deletions`
-    const result = {
-      status: isMergeable ? 'pass' : 'fail',
-      description: isMergeable
-        ? 'PR size is OK!'
-        : validationSettings.lines.max.message || defaultFailMessage
-    }
-    const output = constructOutput(
-      validatorContext,
-      inputMessage,
-      validationSettings,
-      result
-    )
+    let isMergeable = true
+    let messages = []
+    let description, defaultFailMessage
 
-    return consolidateResult([output], validatorContext)
+    if (!!validationSettings.lines.additions && !!validationSettings.lines.additions.count) {
+      isMergeable = additions <= validationSettings.lines.additions.count
+      defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.additions.count} additions`
+      description = isMergeable
+      ? 'PR size for additions is OK!'
+      : validationSettings.lines.additions.message || defaultFailMessage
+      messages.push(description)
+    }
+
+    if (!!validationSettings.lines.deletions && !!validationSettings.lines.deletions.count) {
+      isMergeable = deletions <= validationSettings.lines.deletions.count
+      defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.deletions.count} deletions`
+      description = isMergeable
+        ? 'PR size for deletions is OK!'
+        : validationSettings.lines.deletions.message || defaultFailMessage
+      messages.push(description)
+    }
+
+    if (!!validationSettings.lines.total && !!validationSettings.lines.total.count) {
+      isMergeable = totalChanges <= validationSettings.lines.total.count
+      defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.total.count} total additions + deletions`
+      description = isMergeable
+        ? 'PR size for total additions + deletions is OK!'
+        : validationSettings.lines.total.message || defaultFailMessage
+      messages.push(description)
+    }
+
+    const output = messages.map(message => {
+      const result = {
+        status: isMergeable ? 'pass' : 'fail',
+        description: message
+      }
+
+      return constructOutput(
+        validatorContext,
+        inputMessage,
+        validationSettings,
+        result
+      )
+    })
+
+    return consolidateResult(output, validatorContext)
   }
 }
 

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -75,32 +75,37 @@ class Size extends Validator {
       )
     }
 
-    let isMergeable = true
+    let isMergeable = {
+      additions: true,
+      deletions: true,
+      total: true
+    }
+
     let messages = []
     let description, defaultFailMessage
 
     if (!!validationSettings.lines.additions && !!validationSettings.lines.additions.count) {
-      isMergeable = additions <= validationSettings.lines.additions.count
+      isMergeable.additions = additions <= validationSettings.lines.additions.count
       defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.additions.count} additions`
-      description = isMergeable
+      description = isMergeable.additions
       ? 'PR size for additions is OK!'
       : validationSettings.lines.additions.message || defaultFailMessage
       messages.push(description)
     }
 
     if (!!validationSettings.lines.deletions && !!validationSettings.lines.deletions.count) {
-      isMergeable = deletions <= validationSettings.lines.deletions.count
+      isMergeable.deletions = deletions <= validationSettings.lines.deletions.count
       defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.deletions.count} deletions`
-      description = isMergeable
+      description = isMergeable.deletions
         ? 'PR size for deletions is OK!'
         : validationSettings.lines.deletions.message || defaultFailMessage
       messages.push(description)
     }
 
     if (!!validationSettings.lines.total && !!validationSettings.lines.total.count) {
-      isMergeable = totalChanges <= validationSettings.lines.total.count
+      isMergeable.total = totalChanges <= validationSettings.lines.total.count
       defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.total.count} total additions + deletions`
-      description = isMergeable
+      description = isMergeable.total
         ? 'PR size for total additions + deletions is OK!'
         : validationSettings.lines.total.message || defaultFailMessage
       messages.push(description)
@@ -108,7 +113,7 @@ class Size extends Validator {
 
     const output = messages.map(message => {
       const result = {
-        status: isMergeable ? 'pass' : 'fail',
+        status: isMergeable.total && isMergeable.additions && isMergeable.deletions ? 'pass' : 'fail',
         description: message
       }
 

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -1,4 +1,5 @@
 const minimatch = require('minimatch')
+const _ = require('lodash')
 
 const { Validator } = require('./validator')
 const constructOutput = require('./options_processor/options/lib/constructOutput')
@@ -26,7 +27,8 @@ class Size extends Validator {
   }
 
   async validate (context, validationSettings) {
-    const ERROR_MESSAGE = `Failed to validate because the 'lines' or 'max' option is missing. Please check the documentation.`
+    const ERROR_MESSAGE = `Failed to validate because the 'lines' or 'max / total', 'additions' or 'deletions' option is missing. Please check the documentation.`
+    const ERROR_MAX_TOTAL = 'Options max and total cannot be used together. Please choose one'
     const VALIDATOR_NAME = 'Size'
     const validatorContext = {name: VALIDATOR_NAME}
 
@@ -49,17 +51,19 @@ class Size extends Validator {
         })
       )
 
-    let additions = 0
-    let deletions = 0
-    let totalChanges = 0
+    let prSizeChanges = {
+      additions: 0,
+      deletions: 0,
+      total: 0
+    }
 
     modifiedFiles.forEach((file) => {
-      additions += file.additions
-      deletions += file.deletions
-      totalChanges += file.changes
+      prSizeChanges.additions += file.additions
+      prSizeChanges.deletions += file.deletions
+      prSizeChanges.total += file.changes
     })
 
-    const inputMessage = `${totalChanges} (${additions} additions, ${deletions} deletions)`
+    const inputMessage = `${prSizeChanges.total} total, ${prSizeChanges.additions} additions, ${prSizeChanges.deletions} deletions`
 
     if (!validationSettings.lines) {
       return consolidateResult(
@@ -75,15 +79,36 @@ class Size extends Validator {
       )
     }
 
+    // lets get available keys. must be either total, max, additions or deletions
+    const prSize = _.pick(validationSettings.lines, ['additions', 'deletions', 'total', 'max'])
+
+    if (!_.isUndefined(prSize.max) && !_.isUndefined(prSize.total)) {
+      return consolidateResult(
+        [
+          constructErrorOutput(
+            VALIDATOR_NAME,
+            inputMessage,
+            validationSettings,
+            ERROR_MAX_TOTAL
+          )
+        ],
+        validatorContext
+      )
+    }
+
+    if (prSize.max) {
+      prSize.total = prSize.max
+      delete prSize.max
+    }
     let output = []
 
-    if (!!validationSettings.lines.additions && !!validationSettings.lines.additions.count) {
-      const isMergeable = additions <= validationSettings.lines.additions.count
-      const defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.additions.count} additions`
+    _.mapKeys(prSize, (value, key) => {
+      const isMergeable = prSizeChanges[key] <= value.count
+      const message = key === 'total' ? 'total additions + deletions' : key
+      const defaultFailMessage = `PR is too large. Should be under ${value.count} ${message}`
       const description = isMergeable
-      ? 'PR size for additions is OK!'
-      : validationSettings.lines.additions.message || defaultFailMessage
-
+        ? `PR size for ${message} is OK!`
+        : value.message || defaultFailMessage
       const result = {
         status: isMergeable ? 'pass' : 'fail',
         description: description
@@ -95,46 +120,20 @@ class Size extends Validator {
         validationSettings,
         result
       ))
-    }
+    })
 
-    if (!!validationSettings.lines.deletions && !!validationSettings.lines.deletions.count) {
-      const isMergeable = deletions <= validationSettings.lines.deletions.count
-      const defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.deletions.count} deletions`
-      const description = isMergeable
-        ? 'PR size for deletions is OK!'
-        : validationSettings.lines.deletions.message || defaultFailMessage
-
-      const result = {
-        status: isMergeable ? 'pass' : 'fail',
-        description: description
-      }
-
-      output.push(constructOutput(
-          validatorContext,
-          inputMessage,
-          validationSettings,
-          result
-        ))
-    }
-
-    if (!!validationSettings.lines.total && !!validationSettings.lines.total.count) {
-      const isMergeable = totalChanges <= validationSettings.lines.total.count
-      const defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.total.count} total additions + deletions`
-      const description = isMergeable
-        ? 'PR size for total additions + deletions is OK!'
-        : validationSettings.lines.total.message || defaultFailMessage
-
-      const result = {
-        status: isMergeable ? 'pass' : 'fail',
-        description: description
-      }
-
-      output.push(constructOutput(
-          validatorContext,
-          inputMessage,
-          validationSettings,
-          result
-        ))
+    if (output.length === 0) {
+      return consolidateResult(
+        [
+          constructErrorOutput(
+            VALIDATOR_NAME,
+            inputMessage,
+            validationSettings,
+            ERROR_MESSAGE
+          )
+        ],
+        validatorContext
+      )
     }
 
     return consolidateResult(output, validatorContext)


### PR DESCRIPTION
This PR adds the ability to specify PR size types. 
```yml
  - do: size
    lines:
      total:
        count: 500
        message: Change is very large. Should be under 500 lines of additions and deletions.
      additions:
        count: 250
        message: Change is very large. Should be under 250 lines of additions 
      deletions:
        count: 500
        message: Change is very large. Should be under 250 lines of deletions.
```