### PR TITLE
fix: Upgrade probots and lodash packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "js-yaml": "^3.11.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.15",
     "node-fetch": "^2.1.2",
-    "probot": "^9.2.5",
+    "probot": "^9.6.6",
     "probot-scheduler": "^2.0.0-beta.1",
     "colors": "^1.3.2",
     "minimatch": "^3.0.4"


### PR DESCRIPTION
Upgrade to the latest versions of these packages. This should hopefully
also fix a prototype pollution vulnerability in lodash (which probots
also pulls in):

https://snyk.io/vuln/SNYK-JS-LODASH-450202