### PR TITLE
fix: isEventInContext

### DIFF
--- a/lib/flex.js
+++ b/lib/flex.js
@@ -110,7 +110,7 @@ const isEventInContext = (event, context) => {
   let contextEvent = `${context.event}.${context.payload.action}`
   let found = eventArray.find(element => {
     if (element.split('.')[1] === '*') {
-      return element.includes(context.event)
+      return element.split('.')[0] === context.event
     } else {
       return element === contextEvent
     }


### PR DESCRIPTION
### Context
Current implementation of isEventInContext function allows matching for multiple events such as `issues` and `issuesComment`. This leads to a bug where if the config specify both those events as different `when`, unintended actions will be fired.

Solution:
strictly check for the correct event type instead of using `includes`