### PR TITLE
fix: Replace deprecated pullRequests attribute

### DIFF
--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -79,7 +79,7 @@ module.exports = {
             return {}
           }
         },
-        pullRequests: {
+        pulls: {
           listFiles: () => {
             if (_.isString(options.files && options.files[0])) {
               return {
@@ -151,7 +151,7 @@ module.exports = {
         content: Buffer.from(configString).toString('base64') }
       })
     }
-    context.github.pullRequests.listFiles = () => {
+    context.github.pulls.listFiles = () => {
       return Promise.resolve({
         data: options && options.files ? options.files.map(file => ({ filename: file, status: 'modified' })) : []
       })

--- a/__tests__/unit/configuration/configuration.test.js
+++ b/__tests__/unit/configuration/configuration.test.js
@@ -368,7 +368,7 @@ const createMockGhConfig = (json, prConfig, options) => {
           })
         })
       },
-      pullRequests: {
+      pulls: {
         listFiles: () => {
           return { data: options.files }
         }

--- a/__tests__/unit/interceptors/checkReRun.test.js
+++ b/__tests__/unit/interceptors/checkReRun.test.js
@@ -10,7 +10,7 @@ test('context is not modified if pre conditions are not met', async () => {
   context.event = 'check_run'
   context.payload.action = 'created'
   Object.set(context, 'payload.check_run.output.text', mockOutput())
-  context.github.pullRequests.get.mockReturnValue({ data: { number: 456 } })
+  context.github.pulls.get.mockReturnValue({ data: { number: 456 } })
   let newContext = await checkReRun.process(context)
 
   expect(newContext.event).toBe('check_run')
@@ -47,7 +47,7 @@ test('#process', async () => {
   Object.set(context, 'payload.check_run.output.text', mockOutput())
   context.payload.check_run.pull_requests = [{number: 1}]
   context.payload.check_run.id = 123
-  context.github.pullRequests.get.mockReturnValue({ data: { number: 456 } })
+  context.github.pulls.get.mockReturnValue({ data: { number: 456 } })
   let newContext = await checkReRun.process(context)
 
   expect(newContext.payload.pull_request.number).toBe(456)

--- a/__tests__/unit/interceptors/milestoned.test.js
+++ b/__tests__/unit/interceptors/milestoned.test.js
@@ -30,7 +30,7 @@ test('#process', async () => {
   context.payload.action = 'milestoned'
   Object.set(context, 'payload.issue.pull_request', {})
   context.payload.issue.number = 12
-  context.github.pullRequests.get.mockReturnValue({ data: { number: 12 } })
+  context.github.pulls.get.mockReturnValue({ data: { number: 12 } })
 
   // make sure we setup context correctly.
   expect(milestoned.valid(context)).toBe(true)

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -100,7 +100,7 @@ class Configuration {
 
     if (['pull_request', 'pull_request_review'].includes(context.event)) {
       // get modified file list
-      let result = await context.github.pullRequests.listFiles(context.repo({pull_number: context.payload.pull_request.number}))
+      let result = await context.github.pulls.listFiles(context.repo({pull_number: context.payload.pull_request.number}))
       let modifiedFiles = result.data
         .filter(file => ['modified', 'added'].includes(file.status))
         .map(file => file.filename)

--- a/lib/interceptors/checkReRun.js
+++ b/lib/interceptors/checkReRun.js
@@ -20,7 +20,7 @@ class CheckReRun extends Interceptor {
     let meta = MetaData.deserialize(checkRun.output.text)
     if (this.possibleInjection(context, checkRun, meta)) return context
 
-    let pr = await context.github.pullRequests.get(context.repo({number: checkRun.pull_requests[0].number}))
+    let pr = await context.github.pulls.get(context.repo({number: checkRun.pull_requests[0].number}))
     context.payload.action = meta.action
     context.event = meta.event
     context.payload.pull_request = pr.data

--- a/lib/interceptors/milestoned.js
+++ b/lib/interceptors/milestoned.js
@@ -6,7 +6,7 @@ const Interceptor = require('./interceptor')
 class Milestoned extends Interceptor {
   async process (context) {
     if (this.valid(context)) {
-      let res = await context.github.pullRequests.get(context.repo({number: context.payload.issue.number}))
+      let res = await context.github.pulls.get(context.repo({number: context.payload.issue.number}))
       res.data.action = context.payload.action
       context.event = 'pull_request'
       context.payload.pull_request = res.data

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -24,7 +24,7 @@ class Approvals extends Validator {
 
   async validate (context, validationSettings) {
     let reviews = await context.github.paginate(
-      context.github.pullRequests.listReviews.endpoint.merge(
+      context.github.pulls.listReviews.endpoint.merge(
         context.repo({ pull_number: this.getPayload(context).number })
       ),
       res => res.data

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -30,7 +30,7 @@ class Dependent extends Validator {
     const DEFUALT_SUCCESS_MESSAGE = 'All the Dependents files are present!'
 
     // fetch the file list
-    let result = await context.github.pullRequests.listFiles(context.repo({pull_number: this.getPayload(context).number}))
+    let result = await context.github.pulls.listFiles(context.repo({pull_number: this.getPayload(context).number}))
     let modifiedFiles = result.data
       .filter(file => file.status === 'modified' || file.status === 'added')
       .map(file => file.filename)

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -34,7 +34,7 @@ class Size extends Validator {
 
     const payload = this.getPayload(context)
     const patternsToIgnore = validationSettings.ignore || []
-    const listFilesResult = await context.github.pullRequests.listFiles(
+    const listFilesResult = await context.github.pulls.listFiles(
       context.repo({pull_number: payload.number})
     )
 


### PR DESCRIPTION
The 'pullRequests' attribute on the GitHub context has been replaced by
'pulls' in Octokit since version 3 of `plugin-rest-endpoint-methods.js` and deprecated in earlier versions:

- https://github.com/octokit/rest.js/releases/tag/v16.43.0
- https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v3.0.0

This was causing the bot to break for me when running locally. Seems the API has changed a little.