### PR TITLE
feat: Remove default config and add new default behaviour

### DIFF
--- a/__tests__/unit/configuration/configuration.test.js
+++ b/__tests__/unit/configuration/configuration.test.js
@@ -149,7 +149,12 @@ describe('config file fetching', () => {
 
 describe('with version 2', () => {
   test('it loads correctly without version', () => {
-    let config = new Configuration()
+    let config = new Configuration(`
+      mergeable:
+        approvals: 5
+        label: 'label regex'
+        title: 'title regex'
+    `)
     expect(config.settings[0].when).toBeDefined()
     expect(config.settings[0].validate).toBeDefined()
     expect(config.hasErrors()).toBe(false)
@@ -298,7 +303,7 @@ describe('with version 1', () => {
     })
   })
 
-  test('that instanceWithContext still returns the Configuration when repo does not content mergeable.yml', async () => {
+  test('that instanceWithContext return error if mergeable.yml is not found', async () => {
     let context = {
       repo: () => {
         return {repo: '', owner: ''}
@@ -323,10 +328,8 @@ describe('with version 1', () => {
     }
 
     let config = await Configuration.instanceWithContext(context)
-    let validate = config.settings[0].validate
-
-    expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe('^wip')
-    expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('work in progress|wip|do not merge')
+    expect(config.hasErrors()).toBe(true)
+    expect(config.errors.has(Configuration.ERROR_CODES.NO_YML)).toBe(true)
   })
 
   test('that if pass, fail or error is undefined in v2 config, the config will not break', async () => {

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -1,34 +1,28 @@
 const yaml = require('js-yaml')
-const consts = require('./lib/consts')
 
 class Configuration {
   constructor (settings) {
     this.errors = new Map()
     this.warnings = new Map()
     if (settings === undefined) {
-      this.settings = [{
-        when: 'pull_request.*',
-        validate: consts.DEFAULT_PR_VALIDATE,
-        pass: consts.DEFAULT_PR_PASS,
-        fail: consts.DEFAULT_PR_FAIL,
-        error: consts.DEFAULT_PR_ERROR
-      }]
-    } else {
-      try {
-        this.settings = yaml.safeLoad(settings)
-      } catch (e) {
-        this.errors.set(ERROR_CODES.BAD_YML, `Invalid YML format > ${e.message}`)
-        return // intentionally return since there's not much more we can do.
-      }
-
-      this.validate()
-      if (this.errors.size > 0) return
-
-      const version = this.checkConfigVersion()
-
-      this.settings = (require(`./transformers/v${version}Config`).transform(this.settings))
-      this.settings = this.settings.mergeable
+      this.errors.set(ERROR_CODES.NO_YML, `No Config File found`)
+      return // intentionally return since there's not much more we can do.
     }
+
+    try {
+      this.settings = yaml.safeLoad(settings)
+    } catch (e) {
+      this.errors.set(ERROR_CODES.BAD_YML, `Invalid YML format > ${e.message}`)
+      return // intentionally return since there's not much more we can do.
+    }
+
+    this.validate()
+    if (this.errors.size > 0) return
+
+    const version = this.checkConfigVersion()
+
+    this.settings = (require(`./transformers/v${version}Config`).transform(this.settings))
+    this.settings = this.settings.mergeable
   }
 
   hasErrors () {
@@ -152,7 +146,8 @@ const ERROR_CODES = {
   MISSING_MERGEABLE_NODE: 20,
   UNKOWN_VERSION: 30,
   CONFIG_NOT_FOUND: 40,
-  GITHUB_API_ERROR: 50
+  GITHUB_API_ERROR: 50,
+  NO_YML: 60
 }
 Configuration.ERROR_CODES = ERROR_CODES
 const ERROR_MESSAGES = {

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -16,7 +16,6 @@ const executeMergeable = async (context, registry) => {
 
   // first fetch the configuration
   let config = await Configuration.instanceWithContext(context)
-  console.log(config)
 
   if (config.hasErrors()) {
     let log = context.log.child({ name: 'mergeable' })

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -16,28 +16,46 @@ const executeMergeable = async (context, registry) => {
 
   // first fetch the configuration
   let config = await Configuration.instanceWithContext(context)
+  console.log(config)
 
   if (config.hasErrors()) {
     let log = context.log.child({ name: 'mergeable' })
     let evt = `${context.event}.${context.payload.action}`
-    log.info('Errors found in yml configuration on %s :\n ', evt, config.errors)
-    let checks = new Checks()
-    if (checks.isEventSupported(evt)) {
-      checks.run({
-        context: context,
-        payload: {
-          status: 'completed',
-          conclusion: 'cancelled',
-          output: {
-            title: 'Invalid Configuration',
-            summary: formatErrorSummary(config.errors)
-          },
-          completed_at: new Date()
-        }
-      })
-    }
+    logAndProcessConfigErrors(context, log, evt, config.errors)
   } else {
     await processWorkflow(context, registry, config)
+  }
+}
+
+const logAndProcessConfigErrors = (context, log, evt, errors) => {
+  let checks = new Checks()
+  if (!checks.isEventSupported(evt)) return
+
+  let checkRunParam = {
+    context: context,
+    payload: {
+      status: 'completed',
+      conclusion: 'cancelled',
+      output: {
+        title: 'Invalid Configuration',
+        summary: formatErrorSummary(errors)
+      },
+      completed_at: new Date()
+    }
+  }
+
+  if (errors.has(Configuration.ERROR_CODES.NO_YML)) {
+    log.info('Errors found in yml configuration on %s :\n ', evt, errors)
+    checkRunParam.payload.conclusion = 'success'
+    checkRunParam.payload.output = {
+      title: 'No Config file found',
+      summary: 'To enable Mergeable, please create a .github/mergeable.yml' +
+        '\n\nSee the [documentation](https://github.com/mergeability/mergeable) for details on configuration.'
+    }
+    checks.run(checkRunParam)
+  } else {
+    log.info('Errors found in yml configuration on %s :\n ', evt, errors)
+    checks.run(checkRunParam)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "LOG_LEVEL=trace NODE_ENV=development nodemon --exec 'npm start'",
     "start": "probot run ./index.js",
-    "test": "jest && standard",
+    "test": "jest __tests__/unit/flex.test.js && standard",
     "test:unit": "LOG_LEVEL=warn jest __tests__/unit/* && standard",
     "test:e2e": "LOG_LEVEL=warn jest __tests__/e2e/* && standard",
     "test-watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "LOG_LEVEL=trace NODE_ENV=development nodemon --exec 'npm start'",
     "start": "probot run ./index.js",
-    "test": "jest __tests__/unit/flex.test.js && standard",
+    "test": "jest && standard",
     "test:unit": "LOG_LEVEL=warn jest __tests__/unit/* && standard",
     "test:e2e": "LOG_LEVEL=warn jest __tests__/e2e/* && standard",
     "test-watch": "jest --watch",


### PR DESCRIPTION
### Context
closes #252 

### Implementation
Instead of creating default config, we create a 'success' check for PRs if no config were found. This is in order to communicate to the user that no configs were found.

![image](https://user-images.githubusercontent.com/5243508/76830361-57b57100-67e2-11ea-970d-1542630aca8a.png)
