### PR TITLE
Add log to show which repo are using mergeable

### DIFF
--- a/lib/flex.js
+++ b/lib/flex.js
@@ -72,6 +72,17 @@ const formatErrorSummary = (errors) => {
 }
 
 const processWorkflow = async (context, registry, config) => {
+  let log = context.log.child({ name: 'mergeable' })
+
+  // log usage of mergeable
+  log.info(`Running Mergeable for: ${context.payload.repository.full_name}`)
+  log.debug({Repo: context.payload.repository.full_name,
+    url: context.payload.repository.html_url,
+    private: context.payload.repository.private,
+    config: config.settings,
+    event: context.event,
+    action: context.payload.action})
+
   // go through the settings and register all the validators
   try {
     register.registerValidatorsAndActions(config.settings, registry)

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -75,8 +75,7 @@ const processWorkflow = async (context, registry, config) => {
   let log = context.log.child({ name: 'mergeable' })
 
   // log usage of mergeable
-  log.info(`Running Mergeable for: ${context.payload.repository.full_name}`)
-  log.debug({Repo: context.payload.repository.full_name,
+  log.info({Repo: context.payload.repository.full_name,
     url: context.payload.repository.html_url,
     private: context.payload.repository.private,
     config: config.settings,


### PR DESCRIPTION
### Context 
We currently have no means of measuring usage and adding log would help us filter usage if we want it later on. Only create logs when main mergeable logic is ran.

@jusx wdyt on this solution for the meantime?