### PR TITLE
docs: add a note about `owners` sub option not working in private repos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ For convenience, wildcards can be used: `pull_request.*`, `issues.*`, `pull_requ
     message: 'Custom message...'
 ```
 
-> ☝ **NOTE:**  `owners` sub-option only works in **public** repos right now, we have plans to enable it for private repo in the future.
+> ☝ **NOTE:**  `owners` sub-option only works in **public** repos right now, we have plans to enable it for private repos in the future.
 
 Supported events:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,8 @@ For convenience, wildcards can be used: `pull_request.*`, `issues.*`, `pull_requ
     message: 'Custom message...'
 ```
 
+> ☝ **NOTE:**  `owners` sub-option only works in **public** repos right now, we have plans to enable it for private repo in the future.
+
 Supported events:
 
 ```js


### PR DESCRIPTION
### Content
Add a note in the readMe to address `owner` sub-options not working in private repos

closes #256 