### PR TITLE
feat: Changeset validator

### DIFF
--- a/__tests__/unit/validators/changeset.test.js
+++ b/__tests__/unit/validators/changeset.test.js
@@ -1,0 +1,76 @@
+const Helper = require('../../../__fixtures__/unit/helper')
+const Changeset = require('../../../lib/validators/changeset')
+
+test('validate returns correctly', async () => {
+  const changeset = new Changeset()
+  const settings = {
+    do: 'changeset',
+    must_exclude: {
+      regex: 'b.js'
+    }
+
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  expect(validation.status).toBe('pass')
+
+  validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'b.js']), settings)
+  expect(validation.status).toBe('fail')
+})
+
+test('fail gracefully if invalid regex', async () => {
+  const changeset = new Changeset()
+  const settings = {
+    do: 'changeset',
+    must_include: {
+      regex: '@#$@#$@#$'
+    }
+
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  expect(validation.status).toBe('fail')
+})
+
+test('mergeable is true if must_include is one of the label', async () => {
+  const changeset = new Changeset()
+  const settings = {
+    do: 'changeset',
+    must_include: {
+      regex: 'a.js'
+    }
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js', 'a.jsx']), settings)
+  expect(validation.status).toBe('pass')
+})
+
+test('mergeable is false if must_exclude is one of the label', async () => {
+  const changeset = new Changeset()
+  const settings = {
+    do: 'changeset',
+    must_include: {
+      regex: 'yarn.lock'
+    }
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  expect(validation.status).toBe('fail')
+})
+
+test('that it validates ends_with correctly', async () => {
+  const changeset = new Changeset()
+  const settings = {
+    do: 'changeset',
+    ends_with: {
+      match: 'lock'
+    }
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  expect(validation.status).toBe('pass')
+})
+
+const createMockContext = (files) => {
+  return Helper.mockContext({files: files})
+}

--- a/__tests__/unit/validators/changeset.test.js
+++ b/__tests__/unit/validators/changeset.test.js
@@ -49,7 +49,7 @@ test('mergeable is false if must_exclude is one of the label', async () => {
   const changeset = new Changeset()
   const settings = {
     do: 'changeset',
-    must_include: {
+    must_exclude: {
       regex: 'yarn.lock'
     }
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -277,6 +277,38 @@ Supported events:
 'pull_request.*', 'pull_request_review.*', 'issues.*'
 ```
 
+### Change Set
+```yml
+  - do: changeset # validate against the files in the PR
+    no_empty:
+       enabled: false # Cannot be empty when true.
+       message: 'Custom message...'
+    must_include:
+       regex: 'yarn.lock'
+       message: 'Custom message...'
+    must_exclude:
+       regex: 'package.json'
+       message: 'Custom message...'
+    begins_with:
+       match: 'A String' # or array of strings
+       message: 'Some message...'
+    ends_with:
+       match: 'A String' # or array of strings
+       message: 'Come message...'
+    min:
+        count: 2 # min number of files in a PR
+        message: 'Custom message...'
+    max:
+       count: 2 # max number of files in a PR
+       message: 'Custom message...'
+    # all of the message sub-option is optional
+```
+Supported events:
+
+```js
+'pull_request.*', 'pull_request_review.*'
+```
+
 ### milestone
 ```yml
 

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -1,0 +1,31 @@
+const { Validator } = require('./validator')
+
+class Changeset extends Validator {
+  constructor () {
+    super('changeset')
+    this.supportedEvents = [
+      'pull_request.opened',
+      'pull_request.edited',
+      'pull_request_review.submitted',
+      'pull_request_review.edited',
+      'pull_request_review.dismissed',
+      'pull_request.labeled',
+      'pull_request.milestoned',
+      'pull_request.demilestoned',
+      'pull_request.assigned',
+      'pull_request.unassigned',
+      'pull_request.unlabeled',
+      'pull_request.synchronize'
+    ]
+  }
+
+  async validate (context, validationSettings) {
+    // fetch the file list
+    let result = await context.github.pulls.listFiles(context.repo({pull_number: this.getPayload(context).number}))
+    let changedFiles = result.data.map(file => file.filename)
+
+    return this.processOptions(validationSettings, changedFiles)
+  }
+}
+
+module.exports = Changeset

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -4,18 +4,7 @@ class Changeset extends Validator {
   constructor () {
     super('changeset')
     this.supportedEvents = [
-      'pull_request.opened',
-      'pull_request.edited',
-      'pull_request_review.submitted',
-      'pull_request_review.edited',
-      'pull_request_review.dismissed',
-      'pull_request.labeled',
-      'pull_request.milestoned',
-      'pull_request.demilestoned',
-      'pull_request.assigned',
-      'pull_request.unassigned',
-      'pull_request.unlabeled',
-      'pull_request.synchronize'
+      'pull_request.*'
     ]
   }
 

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -4,7 +4,8 @@ class Changeset extends Validator {
   constructor () {
     super('changeset')
     this.supportedEvents = [
-      'pull_request.*'
+      'pull_request.*',
+      'pull_request_review.*'
     ]
   }
 


### PR DESCRIPTION
### Context 
new validator: `changeset` validate against the files in the PR
config 
```
- do: changeset
    no_empty:
       enabled: false # Cannot be empty when true.
       message: 'Custom message...'
    must_include:
       regex: 'yarn.lock'
       message: 'Custom message...'
    must_exclude:
       regex: 'package.json'
       message: 'Custom message...'
    begins_with:
       match: 'A String' # or array of strings
       message: 'Some message...'
    ends_with:
       match: 'A String' # or array of strings
       message: 'Come message...'
    min:
        count: 2 # min number of files in a PR
        message: 'Custom message...'
    max:
       count: 2 # max number of files in a PR
       message: 'Custom message...'
    # all of the message sub-option is optional
```

closes #184 