### PR TITLE
feat: Regex flag to must_include and must_exclude sub options

### DIFF
--- a/__tests__/unit/validators/options_processor/options/must_exclude.test.js
+++ b/__tests__/unit/validators/options_processor/options/must_exclude.test.js
@@ -38,3 +38,10 @@ test('return error if inputs are not in expected format', async () => {
     expect(e.message).toBe(`Failed to run the test because 'regex' is not provided for 'must_exclude' option. Please check README for more information about configuration`)
   }
 })
+
+test('that regex_flag works as expected', async () => {
+  const rule = {must_exclude: {regex: 'test', regex_flag: ''}}
+  const input = ['A', 'B', 'Test']
+  const res = mustExclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('pass')
+})

--- a/__tests__/unit/validators/options_processor/options/must_exclude.test.js
+++ b/__tests__/unit/validators/options_processor/options/must_exclude.test.js
@@ -40,7 +40,7 @@ test('return error if inputs are not in expected format', async () => {
 })
 
 test('that regex_flag works as expected', async () => {
-  const rule = {must_exclude: {regex: 'test', regex_flag: ''}}
+  const rule = {must_exclude: {regex: 'test', regex_flag: 'none'}}
   const input = ['A', 'B', 'Test']
   const res = mustExclude.process(validatorContext, input, rule)
   expect(res.status).toBe('pass')

--- a/__tests__/unit/validators/options_processor/options/must_include.test.js
+++ b/__tests__/unit/validators/options_processor/options/must_include.test.js
@@ -41,7 +41,7 @@ test('return error if inputs are not in expected format', async () => {
 })
 
 test('that regex_flag works as expected', async () => {
-  const rule = {must_include: {regex: 'test', regex_flag: ''}}
+  const rule = {must_include: {regex: 'test', regex_flag: 'none'}}
   const input = ['A', 'B', 'Test']
   const res = mustInclude.process(validatorContext, input, rule)
   expect(res.status).toBe('fail')

--- a/__tests__/unit/validators/options_processor/options/must_include.test.js
+++ b/__tests__/unit/validators/options_processor/options/must_include.test.js
@@ -39,3 +39,10 @@ test('return error if inputs are not in expected format', async () => {
     expect(e.message).toBe(`Failed to run the test because 'regex' is not provided for 'must_include' option. Please check README for more information about configuration`)
   }
 })
+
+test('that regex_flag works as expected', async () => {
+  const rule = {must_include: {regex: 'test', regex_flag: ''}}
+  const input = ['A', 'B', 'Test']
+  const res = mustInclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('fail')
+})

--- a/docs/README.md
+++ b/docs/README.md
@@ -231,13 +231,13 @@ completely deleted in the PR.
        message: 'Custom message...' # this is optional, a default message is used when not specified.
     must_include:
        regex: '### Goals|### Changes'
-       regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
+       regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'
        message: >
         Please describe the goals (why) and changes (what) of the PR.
       # message is is optional, a default message is used when not specified.
     must_exclude:
        regex: 'DO NOT MERGE'
-       regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
+       regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'
        message: 'Custom message...' # optional
     begins_with:
        match: '### Goals' # or array of strings
@@ -261,11 +261,11 @@ Supported events:
        message: 'Custom message...'
     must_include:
        regex: 'type|chore|wont'
-       regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
+       regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'
        message: 'Custom message...'
     must_exclude:
        regex: 'DO NOT MERGE'
-       regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
+       regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'
        message: 'Custom message...'
     begins_with:
        match: 'A String' # or array of strings
@@ -290,11 +290,11 @@ Supported events:
      message: 'Custom message...'
   must_include:
      regex: 'type|chore|wont'
-     regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
+     regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'
      message: 'Custom message...'
   must_exclude:
      regex: 'DO NOT MERGE'
-     regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
+     regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'
      message: 'Custom message...'
   begins_with:
      match: 'A String' # array of strings
@@ -352,11 +352,11 @@ Supported events:
      message: 'Custom message...'
   must_include:
      regex: 'doc|feat|fix|chore'
-     regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
+     regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'
      message: 'Custom message...'
   must_exclude:
      regex: 'DO NOT MERGE|WIP'
-     regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
+     regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'
      message: 'Custom message...'
   begins_with:
      match: ['doc','feat','fix','chore']

--- a/docs/README.md
+++ b/docs/README.md
@@ -231,11 +231,13 @@ completely deleted in the PR.
        message: 'Custom message...' # this is optional, a default message is used when not specified.
     must_include:
        regex: '### Goals|### Changes'
+       regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
        message: >
         Please describe the goals (why) and changes (what) of the PR.
       # message is is optional, a default message is used when not specified.
     must_exclude:
        regex: 'DO NOT MERGE'
+       regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
        message: 'Custom message...' # optional
     begins_with:
        match: '### Goals' # or array of strings
@@ -259,9 +261,11 @@ Supported events:
        message: 'Custom message...'
     must_include:
        regex: 'type|chore|wont'
+       regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
        message: 'Custom message...'
     must_exclude:
        regex: 'DO NOT MERGE'
+       regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
        message: 'Custom message...'
     begins_with:
        match: 'A String' # or array of strings
@@ -286,9 +290,11 @@ Supported events:
      message: 'Custom message...'
   must_include:
      regex: 'type|chore|wont'
+     regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
      message: 'Custom message...'
   must_exclude:
      regex: 'DO NOT MERGE'
+     regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
      message: 'Custom message...'
   begins_with:
      match: 'A String' # array of strings
@@ -346,9 +352,11 @@ Supported events:
      message: 'Custom message...'
   must_include:
      regex: 'doc|feat|fix|chore'
+     regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
      message: 'Custom message...'
   must_exclude:
      regex: 'DO NOT MERGE|WIP'
+     regex_flag: '' # Optional. Specify the flag for Regex. default is 'i', to disable default use ''
      message: 'Custom message...'
   begins_with:
      match: ['doc','feat','fix','chore']

--- a/lib/validators/options_processor/options/must_exclude.js
+++ b/lib/validators/options_processor/options/must_exclude.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 const REGEX_NOT_FOUND_ERROR = `Failed to run the test because 'regex' is not provided for 'must_exclude' option. Please check README for more information about configuration`
 const UNKNOWN_INPUT_TYPE_ERROR = `Input type invalid, expected either string or array of string as input`
 
@@ -20,11 +18,9 @@ class MustExclude {
     let regexObj
 
     try {
-      let regexFlag
-      if (_.isUndefined(filter.regex_flag)) {
-        regexFlag = 'i'
-      } else {
-        regexFlag = filter.regex_flag.trim() === '' ? '' : filter.regex_flag
+      let regexFlag = 'i'
+      if (filter.regex_flag) {
+        regexFlag = filter.regex_flag === 'none' ? '' : filter.regex_flag
       }
 
       regexObj = new RegExp(regex, regexFlag)

--- a/lib/validators/options_processor/options/must_exclude.js
+++ b/lib/validators/options_processor/options/must_exclude.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 const REGEX_NOT_FOUND_ERROR = `Failed to run the test because 'regex' is not provided for 'must_exclude' option. Please check README for more information about configuration`
 const UNKNOWN_INPUT_TYPE_ERROR = `Input type invalid, expected either string or array of string as input`
 
@@ -18,8 +20,14 @@ class MustExclude {
     let regexObj
 
     try {
-      const regexFlags = rule.regex_flags ? rule.regex_flags : 'i'
-      regexObj = new RegExp(regex, regexFlags)
+      let regexFlag
+      if (_.isUndefined(filter.regex_flag)) {
+        regexFlag = 'i'
+      } else {
+        regexFlag = filter.regex_flag.trim() === '' ? '' : filter.regex_flag
+      }
+
+      regexObj = new RegExp(regex, regexFlag)
     } catch (err) {
       throw new Error(`Failed to create a regex expression with the provided regex: ${regex}`)
     }

--- a/lib/validators/options_processor/options/must_exclude.js
+++ b/lib/validators/options_processor/options/must_exclude.js
@@ -18,7 +18,8 @@ class MustExclude {
     let regexObj
 
     try {
-      regexObj = new RegExp(regex, 'i')
+      const regexFlags = rule.regex_flags ? rule.regex_flags : 'i'
+      regexObj = new RegExp(regex, regexFlags)
     } catch (err) {
       throw new Error(`Failed to create a regex expression with the provided regex: ${regex}`)
     }

--- a/lib/validators/options_processor/options/must_include.js
+++ b/lib/validators/options_processor/options/must_include.js
@@ -18,7 +18,8 @@ class MustInclude {
     let regexObj
 
     try {
-      regexObj = new RegExp(regex, 'i')
+      const regexFlags = rule.regex_flags ? rule.regex_flags : 'i'
+      regexObj = new RegExp(regex, regexFlags)
     } catch (err) {
       throw new Error(`Failed to create a regex expression with the provided regex: ${regex}`)
     }

--- a/lib/validators/options_processor/options/must_include.js
+++ b/lib/validators/options_processor/options/must_include.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 const REGEX_NOT_FOUND_ERROR = `Failed to run the test because 'regex' is not provided for 'must_include' option. Please check README for more information about configuration`
 const UNKNOWN_INPUT_TYPE_ERROR = `Input type invalid, expected either string or array of string as input`
 
@@ -18,8 +20,14 @@ class MustInclude {
     let regexObj
 
     try {
-      const regexFlags = rule.regex_flags ? rule.regex_flags : 'i'
-      regexObj = new RegExp(regex, regexFlags)
+      let regexFlag
+      if (_.isUndefined(filter.regex_flag)) {
+        regexFlag = 'i'
+      } else {
+        regexFlag = filter.regex_flag.trim() === '' ? '' : filter.regex_flag
+      }
+
+      regexObj = new RegExp(regex, regexFlag)
     } catch (err) {
       throw new Error(`Failed to create a regex expression with the provided regex: ${regex}`)
     }

--- a/lib/validators/options_processor/options/must_include.js
+++ b/lib/validators/options_processor/options/must_include.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 const REGEX_NOT_FOUND_ERROR = `Failed to run the test because 'regex' is not provided for 'must_include' option. Please check README for more information about configuration`
 const UNKNOWN_INPUT_TYPE_ERROR = `Input type invalid, expected either string or array of string as input`
 
@@ -20,11 +18,9 @@ class MustInclude {
     let regexObj
 
     try {
-      let regexFlag
-      if (_.isUndefined(filter.regex_flag)) {
-        regexFlag = 'i'
-      } else {
-        regexFlag = filter.regex_flag.trim() === '' ? '' : filter.regex_flag
+      let regexFlag = 'i'
+      if (filter.regex_flag) {
+        regexFlag = filter.regex_flag === 'none' ? '' : filter.regex_flag
       }
 
       regexObj = new RegExp(regex, regexFlag)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0-only",
   "repository": "https://github.com/mergeability/mergeable.git",
   "scripts": {
-    "dev": "LOG_LEVEL=info NODE_ENV=development nodemon --exec 'npm start'",
+    "dev": "NODE_ENV=development nodemon --exec 'npm start'",
     "start": "probot run ./index.js",
     "test": "NODE_ENV=test jest && standard",
     "test:unit": "LOG_LEVEL=warn NODE_ENV=test jest __tests__/unit/* && standard",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "license": "AGPL-3.0-only",
   "repository": "https://github.com/mergeability/mergeable.git",
   "scripts": {
-    "dev": "LOG_LEVEL=trace NODE_ENV=development nodemon --exec 'npm start'",
+    "dev": "LOG_LEVEL=info NODE_ENV=development nodemon --exec 'npm start'",
     "start": "probot run ./index.js",
-    "test": "NODE_ENV=test jest && standard",
+    "test": "NODE_ENV=test jest __tests__/unit/validators/changeset.test.js && standard",
     "test:unit": "LOG_LEVEL=warn NODE_ENV=test jest __tests__/unit/* && standard",
     "test:e2e": "LOG_LEVEL=warn NODE_ENV=test jest __tests__/e2e/* && standard",
     "test-watch": "NODE_ENV=test jest --watch",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "LOG_LEVEL=info NODE_ENV=development nodemon --exec 'npm start'",
     "start": "probot run ./index.js",
-    "test": "NODE_ENV=test jest __tests__/unit/validators/changeset.test.js && standard",
+    "test": "NODE_ENV=test jest && standard",
     "test:unit": "LOG_LEVEL=warn NODE_ENV=test jest __tests__/unit/* && standard",
     "test:e2e": "LOG_LEVEL=warn NODE_ENV=test jest __tests__/e2e/* && standard",
     "test-watch": "NODE_ENV=test jest --watch",


### PR DESCRIPTION
### Context
add the ability for user to define regex_flag to be used in `must_include` and `must_exclude`
leaving 'i' option as default for backward compatibility. 
sample config 
```
- do: labels
        must_exclude:
          regex: 'ABC.js'
          regex_flags: '' # putting '' will remove the default 'i' options 
```
closes #226 