### PR TITLE
feat: add more validations to configuration

### DIFF
--- a/__tests__/unit/configuration/configuration.test.js
+++ b/__tests__/unit/configuration/configuration.test.js
@@ -23,6 +23,7 @@ describe('Loading bad configuration', () => {
     let config = new Configuration(`
     version: not a number
     mergeable:
+      pull_request:
     `)
     expect(config.errors.size).toBe(1)
     expect(config.errors.has(Configuration.ERROR_CODES.UNKOWN_VERSION)).toBe(true)
@@ -35,6 +36,79 @@ describe('Loading bad configuration', () => {
     `)
     expect(config.errors.size).toBe(1)
     expect(config.errors.has(Configuration.ERROR_CODES.MISSING_MERGEABLE_NODE)).toBe(true)
+  })
+
+  test('missing rule sets', () => {
+    let config = new Configuration(`
+    version: 2
+    mergeable:
+    `)
+    expect(config.errors.size).toBe(1)
+    expect(config.errors.has(Configuration.ERROR_CODES.MISSING_RULE_SETS)).toBe(true)
+  })
+  test('v2: non array rule set', () => {
+    let config = new Configuration(`
+    version: 2
+    mergeable:
+      when: test
+    `)
+
+    expect(config.errors.size).toBe(1)
+    expect(config.errors.has(Configuration.ERROR_CODES.NON_ARRAY_MERGEABLE)).toBe(true)
+  })
+
+  test('v2: missing/typo in "validate" keyword multiple rule sets', () => {
+    let config = new Configuration(`
+    version: 2
+    mergeable:
+      - when: pull_requests.*
+        validate:
+          - do :
+      - when: issues.*
+        valdate:
+    `)
+    expect(config.errors.size).toBe(1)
+    expect(config.errors.has(Configuration.ERROR_CODES.MISSING_VALIDATE_KEYWORD)).toBe(true)
+
+    config = new Configuration(`
+    version: 2
+    mergeable:
+      - when: pull_requests.*
+    `)
+    expect(config.errors.size).toBe(1)
+    expect(config.errors.has(Configuration.ERROR_CODES.MISSING_VALIDATE_KEYWORD)).toBe(true)
+  })
+
+  test('v2: non-array "validate" node', () => {
+    let config = new Configuration(`
+    version: 2
+    mergeable:
+      - when: pull_requests.*
+        validate:
+    `)
+    expect(config.errors.size).toBe(1)
+    expect(config.errors.has(Configuration.ERROR_CODES.NON_ARRAY_VALIDATE)).toBe(true)
+
+    config = new Configuration(`
+    version: 2
+    mergeable:
+      - when: pull_requests.*
+        validate:
+          do : title
+    `)
+    expect(config.errors.size).toBe(1)
+    expect(config.errors.has(Configuration.ERROR_CODES.NON_ARRAY_VALIDATE)).toBe(true)
+  })
+
+  test('v2: missing/typo in "when" keyword rule sets', () => {
+    let config = new Configuration(`
+    version: 2
+    mergeable:
+      - validate:
+          - do :
+    `)
+    expect(config.errors.size).toBe(1)
+    expect(config.errors.has(Configuration.ERROR_CODES.MISSING_WHEN_KEYWORD)).toBe(true)
   })
 
   test('multiple errors', () => {

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -1,4 +1,5 @@
 const yaml = require('js-yaml')
+const _ = require('lodash')
 
 class Configuration {
   constructor (settings) {
@@ -35,17 +36,59 @@ class Configuration {
   }
 
   validate () {
-    if (this.settings.mergeable === undefined) {
-      this.errors.set(
-        ERROR_CODES.MISSING_MERGEABLE_NODE,
-        ERROR_MESSAGES.MISSING_MERGEABLE_NODE
-      )
-    }
     if (this.settings.version && typeof this.settings.version !== 'number') {
       this.errors.set(
         ERROR_CODES.UNKOWN_VERSION,
         ERROR_MESSAGES.UNKNOWN_VERSION
       )
+    }
+    if (this.settings.mergeable === undefined) {
+      this.errors.set(
+        ERROR_CODES.MISSING_MERGEABLE_NODE,
+        ERROR_MESSAGES.MISSING_MERGEABLE_NODE
+      )
+      return
+    }
+
+    if (this.settings.mergeable === null) {
+      this.errors.set(
+        ERROR_CODES.MISSING_RULE_SETS,
+        ERROR_MESSAGES.MISSING_RULE_SETS
+      )
+      return
+    }
+
+    if (this.checkConfigVersion() === 2) {
+      if (!_.isArray(this.settings.mergeable)) {
+        this.errors.set(
+          ERROR_CODES.NON_ARRAY_MERGEABLE,
+          ERROR_MESSAGES.NON_ARRAY_MERGEABLE
+        )
+        return
+      }
+
+      this.settings.mergeable.forEach(ruleSet => {
+        if (_.isUndefined(ruleSet.when)) {
+          this.errors.set(
+            ERROR_CODES.MISSING_WHEN_KEYWORD,
+            ERROR_MESSAGES.MISSING_WHEN_KEYWORD
+          )
+        }
+        if (_.isUndefined(ruleSet.validate)) {
+          this.errors.set(
+            ERROR_CODES.MISSING_VALIDATE_KEYWORD,
+            ERROR_MESSAGES.MISSING_VALIDATE_KEYWORD
+          )
+          return
+        }
+
+        if (!_.isArray(ruleSet.validate)) {
+          this.errors.set(
+            ERROR_CODES.NON_ARRAY_VALIDATE,
+            ERROR_MESSAGES.NON_ARRAY_VALIDATE
+          )
+        }
+      })
     }
   }
 
@@ -108,11 +151,21 @@ const ERROR_CODES = {
   UNKOWN_VERSION: 30,
   CONFIG_NOT_FOUND: 40,
   GITHUB_API_ERROR: 50,
-  NO_YML: 60
+  NO_YML: 60,
+  MISSING_RULE_SETS: 70,
+  NON_ARRAY_MERGEABLE: 80,
+  MISSING_WHEN_KEYWORD: 90,
+  MISSING_VALIDATE_KEYWORD: 100,
+  NON_ARRAY_VALIDATE: 110
 }
 Configuration.ERROR_CODES = ERROR_CODES
 const ERROR_MESSAGES = {
   MISSING_MERGEABLE_NODE: 'The `mergeable` node is missing.',
+  MISSING_RULE_SETS: '`mergeable` node does not contain any rule sets',
+  NON_ARRAY_MERGEABLE: '`mergeable` must be an array for version 2 config',
+  MISSING_WHEN_KEYWORD: 'One or more rule set is missing `when` keyword',
+  MISSING_VALIDATE_KEYWORD: 'One or more rule set is missing `validate` keyword',
+  NON_ARRAY_VALIDATE: '`validate` must be an array of rules',
   UNKNOWN_VERSION: 'Invalid `version` found.'
 }
 


### PR DESCRIPTION
### Context
Add more checks in validating the config file 
added checks 
- `mergeable` node must not be empty
- for v2: check that `mergeable` is an Array
- for v2: each element in `mergeable` array has both `when` and `validate` keyword
- for v2: `validate` keyword must be non-empty and an array

![image](https://user-images.githubusercontent.com/5243508/78471021-c94a5600-76e2-11ea-8cde-8d82a6b518f2.png)

closes #263 
