### PR TITLE
feat: commit validator

### DIFF
--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -102,6 +102,13 @@ module.exports = {
               return { data: options.files && options.files }
             }
           },
+          listCommits: {
+            endpoint: {
+              merge: async () => {
+                return { data: (options.commits) ? options.commits : [] }
+              }
+            }
+          },
           listReviews: {
             endpoint: {
               merge: async () => {

--- a/__tests__/unit/validators/commit.test.js
+++ b/__tests__/unit/validators/commit.test.js
@@ -1,0 +1,63 @@
+const Helper = require('../../../__fixtures__/unit/helper')
+const Commit = require('../../../lib/validators/commit')
+
+test('validate returns correctly', async () => {
+  const changeset = new Commit()
+  const settings = {
+    do: 'changeset',
+    must_exclude: {
+      regex: 'b.js'
+    }
+
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  expect(validation.status).toBe('pass')
+
+  validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'b.js']), settings)
+  expect(validation.status).toBe('fail')
+})
+
+test('oldest_only sub option', async () => {
+  const changeset = new Commit()
+  const settings = {
+    do: 'changeset',
+    must_include: {
+      regex: '@#$@#$@#$'
+    }
+
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  expect(validation.status).toBe('fail')
+})
+
+test('skip_merge sub option', async () => {
+  const changeset = new Commit()
+  const settings = {
+    do: 'changeset',
+    must_include: {
+      regex: 'a.js'
+    }
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js', 'a.jsx']), settings)
+  expect(validation.status).toBe('pass')
+})
+
+test('error handling', async () => {
+  const changeset = new Commit()
+  const settings = {
+    do: 'changeset',
+    must_exclude: {
+      regex: 'yarn.lock'
+    }
+  }
+
+  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  expect(validation.status).toBe('fail')
+})
+
+const createMockContext = (files) => {
+  return Helper.mockContext({files: files})
+}

--- a/__tests__/unit/validators/commit.test.js
+++ b/__tests__/unit/validators/commit.test.js
@@ -2,62 +2,156 @@ const Helper = require('../../../__fixtures__/unit/helper')
 const Commit = require('../../../lib/validators/commit')
 
 test('validate returns correctly', async () => {
-  const changeset = new Commit()
+  const commit = new Commit()
   const settings = {
-    do: 'changeset',
-    must_exclude: {
-      regex: 'b.js'
+    do: 'commit',
+    message: {
+      regex: 'feat:'
     }
-
   }
+  const date = Date.now()
+  const commits = [
+    {
+      commit: {
+        author: {
+          date
+        },
+        message: 'fix: this'
+      }
+    },
+    {
+      commit: {
+        author: {
+          date: date + 1
+        },
+        message: 'feat: that'
+      }
+    }
+  ]
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
-  expect(validation.status).toBe('pass')
-
-  validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'b.js']), settings)
+  let validation = await commit.validate(createMockContext(commits), settings)
   expect(validation.status).toBe('fail')
+
+  commits[0].commit.message = 'feat: this'
+
+  validation = await commit.validate(createMockContext(commits), settings)
+  expect(validation.status).toBe('pass')
 })
 
 test('oldest_only sub option', async () => {
-  const changeset = new Commit()
+  const commit = new Commit()
   const settings = {
-    do: 'changeset',
-    must_include: {
-      regex: '@#$@#$@#$'
+    do: 'commit',
+    message: {
+      regex: 'feat:',
+      oldest_only: true
     }
-
   }
+  const date = Date.now()
+  const commits = [
+    {
+      commit: {
+        author: {
+          date
+        },
+        message: 'fix: this'
+      }
+    },
+    {
+      commit: {
+        author: {
+          date: date + 1
+        },
+        message: 'fix: that'
+      }
+    }
+  ]
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  let validation = await commit.validate(createMockContext(commits), settings)
   expect(validation.status).toBe('fail')
-})
 
-test('skip_merge sub option', async () => {
-  const changeset = new Commit()
-  const settings = {
-    do: 'changeset',
-    must_include: {
-      regex: 'a.js'
-    }
-  }
+  commits[0].commit.message = 'feat: this'
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js', 'a.jsx']), settings)
+  validation = await commit.validate(createMockContext(commits), settings)
   expect(validation.status).toBe('pass')
 })
 
-test('error handling', async () => {
-  const changeset = new Commit()
+test('skip_merge sub option', async () => {
+  const commit = new Commit()
   const settings = {
-    do: 'changeset',
-    must_exclude: {
-      regex: 'yarn.lock'
+    do: 'commit',
+    message: {
+      regex: 'feat:',
+      skip_merge: false
     }
   }
+  const date = Date.now()
+  const commits = [
+    {
+      commit: {
+        author: {
+          date
+        },
+        message: 'feat: this'
+      }
+    },
+    {
+      commit: {
+        author: {
+          date: date + 1
+        },
+        message: 'Merge branch'
+      }
+    }
+  ]
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  let validation = await commit.validate(createMockContext(commits), settings)
   expect(validation.status).toBe('fail')
+
+  settings.message.skip_merge = true
+  validation = await commit.validate(createMockContext(commits), settings)
+  expect(validation.status).toBe('pass')
 })
 
-const createMockContext = (files) => {
-  return Helper.mockContext({files: files})
+test('single_commit_only sub option', async () => {
+  const commit = new Commit()
+  const settings = {
+    do: 'commit',
+    message: {
+      regex: 'feat:',
+      single_commit_only: true
+    }
+  }
+  const date = Date.now()
+  const commits = [
+    {
+      commit: {
+        author: {
+          date
+        },
+        message: 'fix: this'
+      }
+    },
+    {
+      commit: {
+        author: {
+          date: date + 1
+        },
+        message: 'test'
+      }
+    }
+  ]
+
+  let validation = await commit.validate(createMockContext(commits), settings)
+  expect(validation.status).toBe('pass')
+  expect(validation.validations[0].description).toBe('Since there are more than one commits, Skipping validation')
+
+  commits.pop()
+  validation = await commit.validate(createMockContext(commits), settings)
+  expect(validation.status).toBe('fail')
+  expect(validation.validations[0].description).toBe('Some or all of your commit messages doesn\'t meet the criteria')
+})
+
+const createMockContext = (commits) => {
+  return Helper.mockContext({commits})
 }

--- a/__tests__/unit/validators/label.test.js
+++ b/__tests__/unit/validators/label.test.js
@@ -79,7 +79,7 @@ test('description is correct', async () => {
   let validation = await label.validate(createMockContext('Work in Progress'), settings)
 
   expect(validation.status).toBe('fail')
-  expect(validation.validations[0].description).toBe('label included "Work in Progress"')
+  expect(validation.validations[0].description).toBe('label does not exclude "Work in Progress"')
 
   validation = await label.validate(createMockContext('Just Label'), settings)
   expect(validation.validations[0].description).toBe("label must exclude 'Work in Progress'")

--- a/__tests__/unit/validators/options_processor/options/must_exclude.test.js
+++ b/__tests__/unit/validators/options_processor/options/must_exclude.test.js
@@ -38,3 +38,14 @@ test('return error if inputs are not in expected format', async () => {
     expect(e.message).toBe(`Failed to run the test because 'regex' is not provided for 'must_exclude' option. Please check README for more information about configuration`)
   }
 })
+
+test('check "all" sub option works', async () => {
+  const rule = {must_exclude: {regex: 'test', all: true}}
+  let input = ['A', 'B', 'the test']
+  let res = mustExclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('fail')
+
+  input = ['A', 'B', 'the']
+  res = mustExclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('pass')
+})

--- a/__tests__/unit/validators/options_processor/options/must_include.test.js
+++ b/__tests__/unit/validators/options_processor/options/must_include.test.js
@@ -39,3 +39,14 @@ test('return error if inputs are not in expected format', async () => {
     expect(e.message).toBe(`Failed to run the test because 'regex' is not provided for 'must_include' option. Please check README for more information about configuration`)
   }
 })
+
+test('check "all" sub option works', async () => {
+  const rule = {must_include: {regex: 'test', all: true}}
+  let input = ['A test', 'B', 'the test']
+  let res = mustInclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('fail')
+
+  input = ['A test', 'B test', 'the test']
+  res = mustInclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('pass')
+})

--- a/docs/README.md
+++ b/docs/README.md
@@ -404,6 +404,11 @@ Supported events:
     single_commint_only: false #Optional, Default is false. only process this validator if there is one commit
     
 ```
+Supported events:
+
+```js
+'pull_request.*', 'pull_request_review.*'
+```
 
 ### Advanced Logic
 Validators can be grouped together with `AND` and `OR` operators:

--- a/docs/README.md
+++ b/docs/README.md
@@ -399,9 +399,9 @@ Supported events:
   messsage:
     regex: '^(feat|docs|chore|fix|refactor|test|style|perf)(\(\w+\))?:.+$'
     message: 'Custom message' # Semantic release conventions must be followed
-    skip_merge: true #Optional, Default is true. Will skip commit with message that includes 'Merge'
-    oldest_only: false #Optional, Default is false. Only check the regex against the oldest commit
-    single_commint_only: false #Optional, Default is false. only process this validator if there is one commit
+    skip_merge: true # Optional, Default is true. Will skip commit with message that includes 'Merge'
+    oldest_only: false # Optional, Default is false. Only check the regex against the oldest commit
+    single_commint_only: false # Optional, Default is false. only process this validator if there is one commit
     
 ```
 Supported events:

--- a/docs/README.md
+++ b/docs/README.md
@@ -393,6 +393,18 @@ Supported events:
      # all of the message sub-option is optional
 ```
 
+### commit
+```yml
+- do: commit
+  messsage:
+    regex: '^(feat|docs|chore|fix|refactor|test|style|perf)(\(\w+\))?:.+$'
+    message: 'Custom message' # Semantic release conventions must be followed
+    skip_merge: true #Optional, Default is true. Will skip commit with message that includes 'Merge'
+    oldest_only: false #Optional, Default is false. Only check the regex against the oldest commit
+    single_commint_only: false #Optional, Default is false. only process this validator if there is one commit
+    
+```
+
 ### Advanced Logic
 Validators can be grouped together with `AND` and `OR` operators:
 

--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -23,8 +23,9 @@ class Commit extends Validator {
     if (_.isUndefined(validationSettings.message.regex)) throw Error(REGEX_NOT_FOUND_ERROR)
 
     let messageSettings = validationSettings.message
-    let oldestCommitOnly = messageSettings.oldest_only ? messageSettings.oldest_only : false
-    let skipMerge = messageSettings.skip_merge ? messageSettings.skip_merge : true
+    let oldestCommitOnly = _.isUndefined(messageSettings.oldest_only) ? false : messageSettings.oldest_only
+    let skipMerge = _.isUndefined(messageSettings.skip_merge) ? true : messageSettings.skip_merge
+    let singleCommitOnly = _.isUndefined(messageSettings.single_commit_only) ? false : messageSettings.single_commit_only
 
     const validatorContext = { name: 'commit' }
 
@@ -35,6 +36,18 @@ class Commit extends Validator {
       res => res.data.map(o => ({ message: o.commit.message, date: o.commit.author.date }))
     )
     let orderedCommits = _.orderBy(commits, ['date'], ['asc'])
+
+    if (singleCommitOnly && orderedCommits.length !== 1) {
+      return consolidateResult([constructOutput(
+        validatorContext,
+        orderedCommits.map(commit => commit.message),
+        validationSettings,
+        {
+          status: 'pass',
+          description: 'Since there are more than one commits, Skipping validation'
+        }
+      )], validatorContext)
+    }
 
     if (skipMerge) {
       orderedCommits = orderedCommits.filter(commit => !commit.message.includes('Merge branch'))

--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -1,0 +1,66 @@
+const { Validator } = require('./validator')
+const _ = require('lodash')
+const mustInclude = require('./options_processor/options/must_include')
+const constructOutput = require('./options_processor/options/lib/constructOutput')
+const consolidateResult = require('./options_processor/options/lib/consolidateResults')
+
+const MESSAGE_NOT_FOUND_ERROR = `Failed to run the 'commit' validator because 'message' option is not found. Please check README for more information about configuration`
+const REGEX_NOT_FOUND_ERROR = `Failed to run the test because 'regex' is not provided for 'message' option. Please check README for more information about configuration`
+const DEFAULT_FAIL_MESSAGE = `Some or all of your commit messages doesn't meet the criteria`
+const DEFAULT_SUCCESS_MESSAGE = `Your commit messages met the specified criteria`
+
+class Commit extends Validator {
+  constructor () {
+    super('dependent')
+    this.supportedEvents = [
+      'pull_request.*',
+      'pull_request_review.*'
+    ]
+  }
+
+  async validate (context, validationSettings) {
+    if (_.isUndefined(validationSettings.message)) throw Error(MESSAGE_NOT_FOUND_ERROR)
+    if (_.isUndefined(validationSettings.message.regex)) throw Error(REGEX_NOT_FOUND_ERROR)
+
+    let messageSettings = validationSettings.message
+    let oldestCommitOnly = messageSettings.oldest_only ? messageSettings.oldest_only : false
+    let skipMerge = messageSettings.skip_merge ? messageSettings.skip_merge : true
+
+    const validatorContext = { name: 'commit' }
+
+    let commits = await context.github.paginate(
+      context.github.pulls.listCommits.endpoint.merge(
+        context.repo({ pull_number: this.getPayload(context).number })
+      ),
+      res => res.data.map(o => ({ message: o.commit.message, date: o.commit.author.date }))
+    )
+    let orderedCommits = _.orderBy(commits, ['date'], ['asc'])
+
+    if (skipMerge) {
+      orderedCommits = orderedCommits.filter(commit => !commit.message.includes('Merge branch'))
+    }
+
+    if (oldestCommitOnly) {
+      orderedCommits = [orderedCommits[0]]
+    }
+
+    const commitMessages = orderedCommits.map(commit => commit.message)
+
+    const result = mustInclude.process(validatorContext, commitMessages, {
+      must_include: {
+        all: true,
+        regex: messageSettings.regex,
+        regex_flag: messageSettings.regex_flag,
+        message: messageSettings.message ? messageSettings.message : DEFAULT_FAIL_MESSAGE
+      }})
+
+    if (result.status === 'pass') {
+      result.description = DEFAULT_SUCCESS_MESSAGE
+    }
+    const output = [constructOutput(validatorContext, commitMessages, validationSettings, result)]
+
+    return consolidateResult(output, validatorContext)
+  }
+}
+
+module.exports = Commit

--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -13,7 +13,8 @@ class Commit extends Validator {
   constructor () {
     super('dependent')
     this.supportedEvents = [
-      'pull_request.synchronize'
+      'pull_request.*',
+      'pull_request_review.*'
     ]
   }
 

--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -13,8 +13,7 @@ class Commit extends Validator {
   constructor () {
     super('dependent')
     this.supportedEvents = [
-      'pull_request.*',
-      'pull_request_review.*'
+      'pull_request.synchronize'
     ]
   }
 

--- a/lib/validators/options_processor/options/must_exclude.js
+++ b/lib/validators/options_processor/options/must_exclude.js
@@ -13,8 +13,8 @@ class MustExclude {
 
     let isMergeable
 
-    const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name} must exclude '${regex}'`
-    if (!description) description = `${validatorContext.name} included "${regex}"`
+    const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name} ${filter.all ? 'all' : ''}must exclude '${regex}'`
+    if (!description) description = `${validatorContext.name} ${filter.all ? 'all' : ''}does not exclude "${regex}"`
     let regexObj
 
     try {
@@ -26,7 +26,11 @@ class MustExclude {
     if (typeof input === 'string') {
       isMergeable = !regexObj.test(input)
     } else if (Array.isArray(input)) {
-      isMergeable = !input.some(label => regexObj.test(label))
+      if (filter.all) {
+        isMergeable = input.every(label => !regexObj.test(label))
+      } else {
+        isMergeable = !input.some(label => regexObj.test(label))
+      }
     } else {
       throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
     }

--- a/lib/validators/options_processor/options/must_include.js
+++ b/lib/validators/options_processor/options/must_include.js
@@ -13,8 +13,8 @@ class MustInclude {
 
     let isMergeable
 
-    const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name} must include '${regex}'`
-    if (!description) description = `${validatorContext.name} does not include "${regex}"`
+    const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name} ${filter.all ? 'all' : ''}must include '${regex}'`
+    if (!description) description = `${validatorContext.name} ${filter.all ? 'all' : ''}does not include "${regex}"`
     let regexObj
 
     try {
@@ -26,7 +26,11 @@ class MustInclude {
     if (typeof input === 'string') {
       isMergeable = regexObj.test(input)
     } else if (Array.isArray(input)) {
-      isMergeable = input.some(label => regexObj.test(label))
+      if (filter.all) {
+        isMergeable = input.every(label => regexObj.test(label))
+      } else {
+        isMergeable = input.some(label => regexObj.test(label))
+      }
     } else {
       throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
     }


### PR DESCRIPTION
### Context
Added a `commit` validator that runs validations against git commits
sample config
```
- do: commit
  messsage:
    regex: '^(feat|docs|chore|fix|refactor|test|style|perf)(\(\w+\))?:.+$'
    message: 'Custom message' # Semantic release conventions must be followed
    skip_merge: true #Optional, Default is true. Will skip commit with message that includes 'Merge'
    oldest_only: false #Optional, Default is false. Only check the regex against the oldest commit
    single_commint_only: false #Optional, Default is false. only process this validator if there is one commit
```
closes #241
