### PR TITLE
fix: stringify json in logs

### DIFF
--- a/lib/actions/action.js
+++ b/lib/actions/action.js
@@ -33,7 +33,7 @@ class Action extends EventAware {
       log_type: logger.logTypes.ACTION_BEFORE_VALIDATE_EXECUTE,
       repo: context.payload.repository.full_name,
       action_name: this.name,
-      settings
+      settings: JSON.stringify(settings)
     }
     this.log.info(usageLog)
   }
@@ -43,7 +43,7 @@ class Action extends EventAware {
       log_type: logger.logTypes.ACTION_AFTER_VALIDATE_EXECUTE,
       repo: context.payload.repository.full_name,
       action_name: this.name,
-      settings
+      settings: JSON.stringify(settings)
     }
     this.log.info(usageLog)
   }

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -28,7 +28,7 @@ const executeMergeable = async (context, registry) => {
     const configLog = {
       log_type: logger.logTypes.CONFIG,
       repo: context.payload.repository.full_name,
-      settings: config.settings
+      settings: JSON.stringify(config.settings)
     }
 
     log.info(configLog)
@@ -63,7 +63,7 @@ const logAndProcessConfigErrors = (context, config) => {
     errors,
     repo: context.payload.repository.full_name,
     event,
-    settings: config.settings
+    settings: JSON.stringify(config.settings)
   }
 
   if (errors.has(Configuration.ERROR_CODES.NO_YML)) {
@@ -130,7 +130,7 @@ const processWorkflow = async (context, registry, config) => {
           errors: err.toString(),
           repo: context.payload.repository.full_name,
           event: `${context.event}.${context.payload.action}`,
-          settings: config.settings
+          settings: JSON.stringify(config.settings)
         }
         log.error(unknownErrorLog)
 
@@ -158,7 +158,7 @@ const processWorkflow = async (context, registry, config) => {
             errors: err.toString(),
             repo: context.payload.repository.full_name,
             event: `${context.event}.${context.payload.action}`,
-            settings: config.settings
+            settings: JSON.stringify(config.settings)
           }
           log.error(unknownErrorLog)
         })

--- a/lib/validators/validator.js
+++ b/lib/validators/validator.js
@@ -45,7 +45,7 @@ class Validator extends EventAware {
       log_type: logger.logTypes.VALIDATOR_PROCESS,
       repo: context.payload.repository.full_name,
       validator_name: this.name,
-      settings
+      settings: JSON.stringify(settings)
     }
     this.log.info(usageLog)
   }


### PR DESCRIPTION
### Context
Our logs are hard to parse because the JSON in the logs are not serialized currently there are multi-line message.