### PR TITLE
fix: serializing in logs

### DIFF
--- a/lib/actions/action.js
+++ b/lib/actions/action.js
@@ -35,7 +35,7 @@ class Action extends EventAware {
       action_name: this.name,
       settings: JSON.stringify(settings)
     }
-    this.log.info(usageLog)
+    this.log.info(JSON.stringify(usageLog))
   }
 
   logAfterValidateUsage (context, settings) {
@@ -45,7 +45,7 @@ class Action extends EventAware {
       action_name: this.name,
       settings: JSON.stringify(settings)
     }
-    this.log.info(usageLog)
+    this.log.info(JSON.stringify(usageLog))
   }
 }
 

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -31,7 +31,7 @@ const executeMergeable = async (context, registry) => {
       settings: JSON.stringify(config.settings)
     }
 
-    log.info(configLog)
+    log.info(JSON.stringify(configLog))
   }
 
   await processWorkflow(context, registry, config)
@@ -77,7 +77,7 @@ const logAndProcessConfigErrors = (context, config) => {
     configErrorLog.log_type = logger.logTypes.CONFIG_NO_YML
   }
 
-  log.info(configErrorLog)
+  log.info(JSON.stringify(configErrorLog))
 
   return checks.run(checkRunParam)
 }

--- a/lib/mergeable.js
+++ b/lib/mergeable.js
@@ -46,7 +46,7 @@ function logEventReceived (context) {
     })
   }
 
-  log.info(eventReceivedLog)
+  log.info(JSON.stringify(eventReceivedLog))
 }
 
 class Mergeable {

--- a/lib/validators/validator.js
+++ b/lib/validators/validator.js
@@ -47,7 +47,7 @@ class Validator extends EventAware {
       validator_name: this.name,
       settings: JSON.stringify(settings)
     }
-    this.log.info(usageLog)
+    this.log.info(JSON.stringify(usageLog))
   }
 }
 


### PR DESCRIPTION
### Context
It seems the changes in #278 is in the right direction but it's still not enough as `bunyan` still truncate the log if the line is too long and put it into a new line which makes things much harder to parse. 
I am expecting these changes will fix the issue