### PR TITLE
feat: allow glob expression in dependent validator and create `requir…

### DIFF
--- a/__tests__/unit/validators/dependent.test.js
+++ b/__tests__/unit/validators/dependent.test.js
@@ -30,7 +30,6 @@ describe('dependent files with modified', () => {
         file: 'package.json',
         files: ['package-lock.json']
       }
-
     }
 
     let validation = await dependent.validate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
@@ -45,10 +44,43 @@ describe('dependent files with modified', () => {
         file: 'package.json',
         files: ['package-lock.json']
       }
+    }
 
+    let validation = await dependent.validate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
+    expect(validation.status).toBe('fail')
+  })
+
+  test('required sub option works as alias for files', async () => {
+    const dependent = new Dependent()
+    const settings = {
+      do: 'dependent',
+      changed: {
+        file: 'package.json',
+        required: ['package-lock.json']
+      }
     }
 
     let validation = await dependent.validate(createMockContext([]), settings)
+    expect(validation.status).toBe('pass')
+  })
+
+  test('glob works with changed file option', async () => {
+    const dependent = new Dependent()
+    const settings = {
+      do: 'dependent',
+      changed: {
+        file: '**/*.js',
+        files: ['package-lock.json']
+      }
+    }
+
+    let validation = await dependent.validate(createMockContext(['a.js']), settings)
+    expect(validation.status).toBe('fail')
+
+    validation = await dependent.validate(createMockContext(['test/test.js']), settings)
+    expect(validation.status).toBe('fail')
+
+    validation = await dependent.validate(createMockContext(['test/test.js', 'package-lock.json']), settings)
     expect(validation.status).toBe('pass')
   })
 })

--- a/docs/README.md
+++ b/docs/README.md
@@ -664,8 +664,8 @@ Validate pull requests for mergeability based on content and structure of your P
       validate:
         - do: dependent
           changed:
-            file: 'package.json'
-            files: ['package-lock.json', 'yarn.lock']
+            file: 'package.json'  # also supports globs expressions
+            required: ['package-lock.json', 'yarn.lock'] # alias: `files` for backward compatibility
   ```
   </p>
 </details>

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -1,5 +1,6 @@
 const { Validator } = require('./validator')
 const _ = require('lodash')
+const minimatch = require('minimatch')
 const constructOutput = require('./options_processor/options/lib/constructOutput')
 const consolidateResult = require('./options_processor/options/lib/consolidateResults')
 const constructError = require('./options_processor/options/lib/constructErrorOutput')
@@ -40,19 +41,24 @@ class Dependent extends Validator {
       return consolidateResult([constructError('Dependent', modifiedFiles, validationSettings, FILES_NOT_FOUND_ERROR)], validatorContext)
     }
 
+    let isMergeable
+    let fileDiff
     // when changed option is specified, the validator uses this instead as it's files to validate
     if (validationSettings.changed) {
-      dependentFiles = modifiedFiles.includes(validationSettings.changed.file)
-        ? [validationSettings.changed.file].concat(validationSettings.changed.files)
+      dependentFiles = modifiedFiles.some((filename) => minimatch(filename, validationSettings.changed.file))
+        ? validationSettings.changed.required ? validationSettings.changed.required : validationSettings.changed.files
         : []
-    }
 
-    const fileDiff = _.difference(dependentFiles, modifiedFiles)
+      fileDiff = _.difference(dependentFiles, modifiedFiles)
+      isMergeable = fileDiff.length === 0
+    } else {
+      fileDiff = _.difference(dependentFiles, modifiedFiles)
+      isMergeable = fileDiff.length === dependentFiles.length || fileDiff.length === 0
+    }
 
     let description = validationSettings.message ||
       `One or more files (${fileDiff.join(', ')}) are missing from your pull request because they are dependent on the following: ${_.difference(dependentFiles, fileDiff)}`
 
-    const isMergeable = dependentFiles.length === fileDiff.length || fileDiff.length === 0
     const output = [constructOutput('Dependent', modifiedFiles, validationSettings, {
       status: isMergeable ? 'pass' : 'fail',
       description: isMergeable ? DEFUALT_SUCCESS_MESSAGE : description


### PR DESCRIPTION
…ed` alias for `files`
### Context 
- allow glob expression in dependent validator 
- create `required` alias for `files`

updated config
```
  version: 2
  mergeable:
    - when: pull_request.*
      validate:
        - do: dependent
          changed:
            file: 'package.json'  # also supports globs expressions
            required: ['package-lock.json', 'yarn.lock'] # alias: `files` for backward compatibility
```

closes #246 