### PR TITLE
fix: add error handling to dependent validator

### DIFF
--- a/__tests__/unit/validators/dependent.test.js
+++ b/__tests__/unit/validators/dependent.test.js
@@ -64,6 +64,20 @@ describe('dependent files with modified', () => {
     expect(validation.status).toBe('pass')
   })
 
+  test('error when "file" sub option is missing', async () => {
+    const dependent = new Dependent()
+    const settings = {
+      do: 'dependent',
+      changed: {
+        required: ['package-lock.json']
+      }
+    }
+
+    let validation = await dependent.validate(createMockContext([]), settings)
+    expect(validation.status).toBe('error')
+    expect(validation.validations[0].description).toBe('Failed to validate because the \'file\' sub option for \'changed\' option is missing. Please check the documentation')
+  })
+
   test('glob works with changed file option', async () => {
     const dependent = new Dependent()
     const settings = {

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -27,6 +27,7 @@ class Dependent extends Validator {
   async validate (context, validationSettings) {
     let dependentFiles = validationSettings.files
 
+    const FILE_NOT_FOUND_ERROR = `Failed to validate because the 'file' sub option for 'changed' option is missing. Please check the documentation`
     const FILES_NOT_FOUND_ERROR = `Failed to validate because the 'files' or 'changed' option is missing. Please check the documentation.`
     const DEFUALT_SUCCESS_MESSAGE = 'All the Dependents files are present!'
 
@@ -45,6 +46,9 @@ class Dependent extends Validator {
     let fileDiff
     // when changed option is specified, the validator uses this instead as it's files to validate
     if (validationSettings.changed) {
+      if (_.isUndefined(validationSettings.changed.file)) {
+        return consolidateResult([constructError('Dependent', modifiedFiles, validationSettings, FILE_NOT_FOUND_ERROR)], validatorContext)
+      }
       dependentFiles = modifiedFiles.some((filename) => minimatch(filename, validationSettings.changed.file))
         ? validationSettings.changed.required ? validationSettings.changed.required : validationSettings.changed.files
         : []


### PR DESCRIPTION
### Context
We are not handling error when `file` sub option is missing properly. This PR is to fix that.


closes #285 