### PR TITLE
docs: fix typo in the commit check example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -404,7 +404,7 @@ Supported events:
 ### commit
 ```yml
 - do: commit
-  messsage:
+  message:
     regex: '^(feat|docs|chore|fix|refactor|test|style|perf)(\(\w+\))?:.+$'
     message: 'Custom message' # Semantic release conventions must be followed
     skip_merge: true # Optional, Default is true. Will skip commit with message that includes 'Merge'


### PR DESCRIPTION
Copy-pasted this example, got this error:

> Error: Failed to run the 'commit' validator because 'message' option is not found. Please check README for more information about configuration