### PR TITLE
docs: fix another typo in the commit check example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -409,7 +409,7 @@ Supported events:
     message: 'Custom message' # Semantic release conventions must be followed
     skip_merge: true # Optional, Default is true. Will skip commit with message that includes 'Merge'
     oldest_only: false # Optional, Default is false. Only check the regex against the oldest commit
-    single_commint_only: false # Optional, Default is false. only process this validator if there is one commit
+    single_commit_only: false # Optional, Default is false. only process this validator if there is one commit
     
 ```
 Supported events:


### PR DESCRIPTION
I'm on a roll today! 😂 A follow up for #287

This one was worse because it it didn't fail the config validation, just failed the `commit` check itself and  I couldn't figure out why it's failing.