### PR TITLE
fix: prevent double logging in check action

### DIFF
--- a/lib/actions/checks.js
+++ b/lib/actions/checks.js
@@ -74,7 +74,6 @@ class Checks extends Action {
   }
 
   async beforeValidate (context) {
-    this.logBeforeValidateUsage(context)
     this.checkRunResult = await createChecks(context, {
       status: 'in_progress',
       output: {
@@ -99,7 +98,6 @@ class Checks extends Action {
   }
 
   async afterValidate (context, settings, results) {
-    this.logAfterValidateUsage(context, settings)
     let payload = this.populatePayloadWithResult(settings.payload, results)
 
     if (payload.text !== undefined) {


### PR DESCRIPTION
### Context
Remove the extra log in check before and after validate functions