### PR TITLE
feat: Add support for default config files

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,3 +15,6 @@ WEBHOOK_SECRET=
 
 # Set this to the webhook URL created with `smee`.
 WEBHOOK_PROXY_URL=
+
+# Needed only for GitHub Enterprise deployments.
+GHE_HOST=

--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const yaml = require('js-yaml')
 
 const throwNotFound = () => {
   let error = new Error('404 error')
@@ -147,6 +148,11 @@ module.exports = {
             return {data: (options.deepValidation) ? options.deepValidation : {}}
           }
         }
+      },
+      probotContext: {
+        config: () => {
+          return Promise.resolve(options.configJson)
+        }
       }
     }
   },
@@ -174,6 +180,9 @@ module.exports = {
       return Promise.resolve({
         data: options && options.files ? options.files.map(file => ({ filename: file, status: 'modified' })) : []
       })
+    }
+    context.probotContext.config = () => {
+      return Promise.resolve(yaml.safeLoad(configString))
     }
   }
 }

--- a/__tests__/unit/flex.test.js
+++ b/__tests__/unit/flex.test.js
@@ -6,6 +6,7 @@ describe('Test processBeforeValidate and processAfterValidate invocations', asyn
   let context
   let registry = { validators: new Map(), actions: new Map() }
   let action
+
   let config = `
     version: 2
     mergeable:
@@ -28,7 +29,7 @@ describe('Test processBeforeValidate and processAfterValidate invocations', asyn
   `
 
   beforeEach(() => {
-    context = Helper.mockContext('title')
+    context = Helper.mockContext()
     Helper.mockConfigWithContext(context, config)
 
     action = new Action()
@@ -75,12 +76,16 @@ describe('Test processBeforeValidate and processAfterValidate invocations', asyn
 
 describe('#executor', () => {
   test('Bad YML', async () => {
-    let context = Helper.mockContext('title')
+    let context = Helper.mockContext()
+    context.event = 'pull_request'
+    context.payload.action = 'opened'
     Helper.mockConfigWithContext(context, `
       version: 2
-      mergeable:
+        mergeable:
     when: pull_request.*
-    `)
+      `,
+      {files: ['.github/mergeable.yml']}
+    )
 
     context.event = 'pull_request'
     context.payload.action = 'opened'

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,9 @@ Some examples of what you can do:
 1. [Install](https://github.com/apps/mergeable) the Mergeable GitHub App.
 2. [Create](#configuration) your recipe(s). Here are some [examples](#examples).
 3. Commit and push the recipes to your repository at `.github/mergeable.yml`
+4. (Optional) You can also create a default configuration for an organisation by
+   creating a repo called `.github` and adding your file there. See [Organisation wide defaults](#organisation-wide-defaults)
+   for details.
 
 > ☝ **NOTE:** You can also [deploy to your own server](deploy.md).
 
@@ -112,7 +115,7 @@ For convenience, wildcards can be used: `pull_request.*`, `issues.*`, `pull_requ
     reviewers: [ user1, user2 ] # list of github usernames required to review
     owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and owners made required reviewers
     assignees: true # Optional boolean. When true, PR assignees are made required reviewers.
-    pending_reviewer: true # Optional boolean. When true, all the requested reviewer's approval is required 
+    pending_reviewer: true # Optional boolean. When true, all the requested reviewer's approval is required
     message: 'Custom message...'
   block:
     changes_requested: true #If true, block all approvals when one of the reviewers gave 'changes_requested' review
@@ -410,7 +413,7 @@ Supported events:
     skip_merge: true # Optional, Default is true. Will skip commit with message that includes 'Merge'
     oldest_only: false # Optional, Default is false. Only check the regex against the oldest commit
     single_commit_only: false # Optional, Default is false. only process this validator if there is one commit
-    
+
 ```
 Supported events:
 
@@ -488,7 +491,7 @@ similarly, `AND` and `OR` can also be nested at the validator level:
       message: 'If no test plan is necessary, please include test plan: no label'
 ```
 
-To reuse certain parts of the config, you can utilize anchor points that `yaml` provides ([link](https://yaml.org/spec/1.2/spec.html#id2785586)), like this 
+To reuse certain parts of the config, you can utilize anchor points that `yaml` provides ([link](https://yaml.org/spec/1.2/spec.html#id2785586)), like this
 
 ```yml
   - do: title
@@ -606,7 +609,7 @@ Supported events:
 ```
 
 ### close
-Close an Issue or Pull Request 
+Close an Issue or Pull Request
 
 ```yml
 - do: close
@@ -731,7 +734,7 @@ Validate pull requests for mergeability based on content and structure of your P
     - when: pull_request.*
       validate:
         - do: project
-          must_include: 
+          must_include:
             regex: MVP
   ```
   </p>
@@ -793,6 +796,38 @@ Detect issues and pull requests that are `n` days old (stale) and notify authors
   ```
   </p>
 </details>
+
+# Organisation-wide defaults
+
+You can specify a default configuration to be applied across your GitHub organisation.
+This can help reduce how many configuration files you need to maintain and make it easier
+to get started with Mergeable.
+
+To add a default configuration:
+
+1. Create a repository called `.github` in your organisation.
+2. Create a file with the path `.github/mergeable.yml` in this repository.
+
+The final path of the file (including the repo name) should be `<YOUR_ORG>/.github/.github/mergeable.yml`
+
+Mergeable will now use this file as the default when it cannot find one in a given
+repository or PR. It determines the file to use in the following order:
+
+1. A `mergeable.yml` inside the PR.
+2. A `mergeable.yml` inside the repository the PR is for.
+3. A `mergeable.yml` at `<YOUR_ORG>/.github/.github/mergeable.yml`.
+
+**Note**: Mergeable will only ever use a _single_ file. It does _not_ merge files.
+
+## Why the weird default file path?
+
+The Probots library that Mergeable uses automatically searches for config files
+in a repo named `.github` within the organisation.
+
+The double nesting of the `<YOUR_ORG>/.github/.github/mergeable.yml` default
+file is unfortunately necessary. The GitHub app permissions model only lets you
+specify a single path for your probot to access, so it must be the same as in
+regular repositories.
 
 # Roadmap
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -47,3 +47,10 @@ Make sure to create a private key for the app after it's been registered.
 This happens when you haven't configured the webhook secret correctly in your
 locally running instance. Make sure to set the `SECRET_TOKEN` environment variable
 in `.env` before running `npm run dev`.
+
+#### `ERROR probot: Integration not found`
+
+This may occur when running Mergeable using a GitHub Enterpise instance.
+
+To fix, try making sure you've set the `GHE_HOST` variable in `.env` to the
+hostname of your Enterprise instance. E.g. `GHE_HOST=github.your_company.com`.

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -6,16 +6,10 @@ class Configuration {
     this.errors = new Map()
     this.warnings = new Map()
     if (settings === undefined) {
-      this.errors.set(ERROR_CODES.NO_YML, `No Config File found`)
       return // intentionally return since there's not much more we can do.
     }
 
-    try {
-      this.settings = yaml.safeLoad(settings)
-    } catch (e) {
-      this.errors.set(ERROR_CODES.BAD_YML, `Invalid YML format > ${e.message}`)
-      return // intentionally return since there's not much more we can do.
-    }
+    this.settings = settings
 
     this.validate()
     if (this.errors.size > 0) return
@@ -111,25 +105,31 @@ class Configuration {
           repo: repo.repo,
           path: Configuration.FILE_NAME,
           ref: context.payload.pull_request.head.sha
+        }).then(response => {
+          return yaml.safeLoad(Buffer.from(response.data.content, 'base64').toString())
         })
       }
     }
 
-    return github.repos.getContents({
-      owner: repo.owner,
-      repo: repo.repo,
-      path: Configuration.FILE_NAME
-    })
+    // probotContext.config loads config from current repo or from a repo called
+    // '.github' in the same organisation as a fallback. It returns the parsed YAML object.
+    const config = await context.probotContext.config('mergeable.yml')
+    if (config === null || config === undefined) {
+      throw new ConfigFileNotFoundException('Could not find config file.')
+    }
+
+    return config
   }
 
   static instanceWithContext (context) {
-    return Configuration.fetchConfigFile(context).then(res => {
-      let content = Buffer.from(res.data.content, 'base64').toString()
-      return new Configuration(content)
+    return Configuration.fetchConfigFile(context).then(config => {
+      return new Configuration(config)
     }).catch(error => {
       let config = new Configuration()
-      if (error.status === 404) {
-        config.warnings.set(WARNING_CODES.CONFIG_NOT_FOUND, WARNING_CONFIG_NOT_FOUND)
+      if (error instanceof ConfigFileNotFoundException) {
+        config.errors.set(ERROR_CODES.NO_YML, `No Config File found`)
+      } else if (error instanceof yaml.YAMLException) {
+        config.errors.set(ERROR_CODES.BAD_YML, `Invalid YML format > ${error.message}`)
       } else {
         const errorMsg = `Github API Error occurred while fetching the config file at ${Configuration.FILE_NAME} \n Error from api: ${error}`
         config.errors.set(ERROR_CODES.GITHUB_API_ERROR, errorMsg)
@@ -138,6 +138,8 @@ class Configuration {
     })
   }
 }
+
+class ConfigFileNotFoundException extends Error {}
 
 Configuration.FILE_NAME = '.github/mergeable.yml'
 Configuration.DEFAULTS = {
@@ -168,12 +170,5 @@ const ERROR_MESSAGES = {
   NON_ARRAY_VALIDATE: '`validate` must be an array of rules',
   UNKNOWN_VERSION: 'Invalid `version` found.'
 }
-
-const WARNING_CODES = {
-  CONFIG_NOT_FOUND: 10
-}
-Configuration.WARNING_CODES = WARNING_CODES
-
-const WARNING_CONFIG_NOT_FOUND = `Configuration file was not found in \`${Configuration.FILE_NAME}\``
 
 module.exports = Configuration


### PR DESCRIPTION
Adds support for specifying default config files in a central repository.
This allows for providing default settings for Mergeable that can be
overriden in individual repos. The purpose is to make it easier to manage
Mergeable across a large number of repos.

The behaviour is quite basic, so there is no support for overriding individual
settings in the configs. Mergeable will use either the default file or the
file in the repo/PR, but never both.

The approach is based on the Probot library which when loading the
config file will look in a repo named '.github' as a fallback. Because
Mergeable can only be granted permission to a specific file path, the
default file needs a somewhat confusing path
('<org>/.github/.github/mergeable.yml').

Addresses:
https://github.com/mergeability/mergeable/issues/244