### PR TITLE
feat: allow approvals to be limited to team members

### DIFF
--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -85,6 +85,9 @@ module.exports = {
             return {}
           }
         },
+        teams: {
+          listMembersInOrg: options.listMembers ? options.listMembers : () => ({ data: [] })
+        },
         pulls: {
           listFiles: () => {
             if (_.isString(options.files && options.files[0])) {

--- a/__tests__/unit/flex.test.js
+++ b/__tests__/unit/flex.test.js
@@ -2,7 +2,7 @@ const executor = require('../../lib/flex')
 const Helper = require('../../__fixtures__/unit/helper')
 const { Action } = require('../../lib/actions/action')
 
-describe('Test processBeforeValidate and processAfterValidate invocations', async () => {
+describe('Test processBeforeValidate and processAfterValidate invocations', () => {
   let context
   let registry = { validators: new Map(), actions: new Map() }
   let action

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,8 @@
 CHANGELOG
 =====================================
 
-May 6, 2020 <Ability to create multiple checks with ``named`` recipe>
-
-May 5, 2020 <Added ability to configure config file name using ``CONFIG_PATH`` env variable>
-
-April 22, 2020 <readthedoc documentation added, start of CHANGELOG>
+May 12 2020 : Limit so that only approval from team members will count, `#236 <https://github.com/mergeability/mergeable/issues/236>`_
+May 6, 2020 : Ability to create multiple checks with ``named`` recipe, `#225 <https://github.com/mergeability/mergeable/issues/225>`_
+May 5, 2020 : Added ability to configure config file name using ``CONFIG_PATH`` env variable, `#223 <https://github.com/mergeability/mergeable/issues/223>`_
+April 22, 2020 : readthedoc documentation added, start of CHANGELOG
 

--- a/docs/validators/approval.rst
+++ b/docs/validators/approval.rst
@@ -14,10 +14,10 @@ Approvals
         pending_reviewer: true # Optional boolean. When true, all the requested reviewer's approval is required
         message: 'Custom message...'
       block:
-        changes_requested: true #If true, block all approvals when one of the reviewers gave 'changes_requested' review
+        changes_requested: true # If true, block all approvals when one of the reviewers gave 'changes_requested' review
         message: 'Custom message...'
       limit:
-        teams: ['org/team_slug'] #when the option is present, only the approvals from the team members will count
+        teams: ['org/team_slug'] # when the option is present, only the approvals from the team members will count
 
 .. warning::
     ``owners`` sub-option only works in public repos right now, we have plans to enable it for private repos in the future.

--- a/docs/validators/approval.rst
+++ b/docs/validators/approval.rst
@@ -16,9 +16,14 @@ Approvals
       block:
         changes_requested: true #If true, block all approvals when one of the reviewers gave 'changes_requested' review
         message: 'Custom message...'
+      limit:
+        teams: ['org/team_slug'] #when the option is present, only the approvals from the team members will count
 
 .. warning::
     ``owners`` sub-option only works in public repos right now, we have plans to enable it for private repos in the future.
+
+.. warning::
+    ``teams`` option will not work right now, it require `team:read` permission which mergeable doesn't have, we have plans to request it in the near future.
 
 Supported Events:
 ::

--- a/lib/errors/teamNotFoundError.js
+++ b/lib/errors/teamNotFoundError.js
@@ -1,0 +1,8 @@
+class TeamNotFoundError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'TeamNotFoundError'
+  }
+}
+
+module.exports = TeamNotFoundError

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -4,6 +4,8 @@ const Assignees = require('./options_processor/assignees')
 const RequestedReviewers = require('./options_processor/requestedReviewers')
 const consolidateResult = require('./options_processor/options/lib/consolidateResults')
 const constructOutput = require('./options_processor/options/lib/constructOutput')
+const constructErrorOutput = require('./options_processor/options/lib/constructErrorOutput')
+const TeamNotFoundError = require('../errors/teamNotFoundError')
 const options = require('./options_processor/options')
 const _ = require('lodash')
 
@@ -40,6 +42,12 @@ class Approvals extends Validator {
       delete validationSettings.block
     }
 
+    let limitOption = null
+    if (validationSettings.limit) {
+      limitOption = validationSettings.limit
+      delete validationSettings.limit
+    }
+
     let reviews = await context.github.paginate(
       context.github.pulls.listReviews.endpoint.merge(
         context.repo({ pull_number: this.getPayload(context).number })
@@ -47,85 +55,143 @@ class Approvals extends Validator {
       res => res.data
     )
 
-    let prCreator = this.getPayload(context).user.login
-    let requiredReviewer = []
+    let { requiredReviewers, ownerList, assigneeList, requestedReviewerList } = await this.getRequiredReviewerList(context, validationSettings)
 
-    if (validationSettings.required &&
-      validationSettings.required.reviewers) {
-      requiredReviewer = validationSettings.required.reviewers
-    }
-
-    const ownerList = (validationSettings && validationSettings.required && validationSettings.required.owners)
-      ? await Owner.process(this.getPayload(context), context) : []
-
-    const assigneeList = (validationSettings && validationSettings.required && validationSettings.required.assignees)
-      ? await Assignees.process(this.getPayload(context), context) : []
-
-    const requestedReviewerList = (validationSettings && validationSettings.required && validationSettings.required.requested_reviewers)
-      ? await RequestedReviewers.process(this.getPayload(context), context) : []
-
-    if (ownerList.length > 0) {
-      // append it to the required reviewer list
-      requiredReviewer = requiredReviewer.concat(ownerList)
-
-      // there could be duplicates between reviewer and ownerlist
-      requiredReviewer = _.uniq(requiredReviewer)
-    }
-
-    if (assigneeList.length > 0) {
-      // append it to the required reviewer list
-      requiredReviewer = requiredReviewer.concat(assigneeList)
-
-      // there could be duplicates between reviewer and assigneeList
-      requiredReviewer = _.uniq(requiredReviewer)
-    }
-
-    if (requestedReviewerList.length > 0) {
-      // append it to the required reviewer list
-      requiredReviewer = requiredReviewer.concat(requestedReviewerList)
-
-      // there could be duplicates between reviewer and assigneeList
-      requiredReviewer = _.uniq(requiredReviewer)
-    }
-
-    if (requiredReviewer.length > 0) {
-      validationSettings = Object.assign({}, validationSettings, {required: { owners: ownerList, assignees: assigneeList, reviewers: requiredReviewer, requested_reviewers: requestedReviewerList }})
+    if (requiredReviewers.length > 0) {
+      validationSettings = Object.assign({}, validationSettings, {required: { owners: ownerList, assignees: assigneeList, reviewers: requiredReviewers, requested_reviewers: requestedReviewerList }})
     }
 
     let approvedReviewers = findReviewersByState(reviews, 'approved')
 
-    // if pr creator exists in the list of required reviewers, remove it
-    if (requiredReviewer.includes(prCreator)) {
-      const foundIndex = requiredReviewer.indexOf(prCreator)
-      requiredReviewer.splice(foundIndex, 1)
+    // if limit is provided, we only filter the approved Reviewers to members of the teams provided
+    if (limitOption && limitOption.teams) {
+      let teamMembers = []
+      for (let team of limitOption.teams) {
+        let members = []
+        try {
+          members = await getTeamMembers(context, team)
+        } catch (err) {
+          if (err instanceof TeamNotFoundError) {
+            const validatorContext = {name: 'approvals'}
+            const output = [constructErrorOutput(validatorContext, team, limitOption, `${err.name}`, err)]
+            return consolidateResult(output, validatorContext)
+          }
+          throw err
+        }
+
+        teamMembers = teamMembers.concat(members)
+      }
+      teamMembers = _.uniq(teamMembers)
+
+      approvedReviewers = _.intersection(approvedReviewers, teamMembers)
     }
 
     let output = await this.processOptions(validationSettings, approvedReviewers)
 
     if (blockOption && blockOption.changes_requested) {
-      const DEFAULT_SUCCESS_MESSAGE = 'No Changes are Requested'
-
-      const description = blockOption.message ? blockOption.message : 'Please resolve all the changes requested'
-
-      const changesRequestedReviewers = findReviewersByState(reviews, 'changes_requested')
-
-      let isMergeable = true
-
-      if (changesRequestedReviewers.length > 0) {
-        isMergeable = false
-      }
-
-      let validatorContext = { name: 'approvals' }
-      let result = {
-        status: isMergeable ? 'pass' : 'fail',
-        description: isMergeable ? DEFAULT_SUCCESS_MESSAGE : description
-      }
-
-      output.push(constructOutput(validatorContext, changesRequestedReviewers, blockOption, result))
+      output.push(processBlockOption(blockOption, reviews))
     }
 
     return consolidateResult(output, { name: 'approvals' })
   }
+
+  async getRequiredReviewerList (context, validationSettings) {
+    let prCreator = this.getPayload(context).user.login
+    let requiredReviewers = []
+
+    if (validationSettings.required &&
+      validationSettings.required.reviewers) {
+      requiredReviewers = validationSettings.required.reviewers
+    }
+
+    const ownerList = (validationSettings && validationSettings.required && validationSettings.required.owners)
+      ? await Owner.process(this.getPayload(context), context) : []
+
+    if (ownerList.length > 0) {
+      // append it to the required reviewer list
+      requiredReviewers = requiredReviewers.concat(ownerList)
+
+      // there could be duplicates between reviewer and ownerlist
+      requiredReviewers = _.uniq(requiredReviewers)
+    }
+
+    const assigneeList = (validationSettings && validationSettings.required && validationSettings.required.assignees)
+      ? await Assignees.process(this.getPayload(context), context) : []
+
+    if (assigneeList.length > 0) {
+      // append it to the required reviewer list
+      requiredReviewers = requiredReviewers.concat(assigneeList)
+
+      // there could be duplicates between reviewer and assigneeList
+      requiredReviewers = _.uniq(requiredReviewers)
+    }
+
+    const requestedReviewerList = (validationSettings && validationSettings.required && validationSettings.required.requested_reviewers)
+      ? await RequestedReviewers.process(this.getPayload(context), context) : []
+
+    if (requestedReviewerList.length > 0) {
+      // append it to the required reviewer list
+      requiredReviewers = requiredReviewers.concat(requestedReviewerList)
+
+      // there could be duplicates between reviewer and assigneeList
+      requiredReviewers = _.uniq(requiredReviewers)
+    }
+
+    // if pr creator exists in the list of required reviewers, remove it
+    if (requiredReviewers.includes(prCreator)) {
+      const foundIndex = requiredReviewers.indexOf(prCreator)
+      requiredReviewers.splice(foundIndex, 1)
+    }
+
+    return { requiredReviewers, ownerList, assigneeList, requestedReviewerList }
+  }
+}
+
+const processBlockOption = (blockOption, reviews) => {
+  const DEFAULT_SUCCESS_MESSAGE = 'No Changes are Requested'
+
+  const description = blockOption.message ? blockOption.message : 'Please resolve all the changes requested'
+
+  const changesRequestedReviewers = findReviewersByState(reviews, 'changes_requested')
+
+  let isMergeable = true
+
+  if (changesRequestedReviewers.length > 0) {
+    isMergeable = false
+  }
+
+  let validatorContext = { name: 'approvals' }
+  let result = {
+    status: isMergeable ? 'pass' : 'fail',
+    description: isMergeable ? DEFAULT_SUCCESS_MESSAGE : description
+  }
+
+  return constructOutput(validatorContext, changesRequestedReviewers, blockOption, result)
+}
+
+const getTeamMembers = async (context, team) => {
+  const stringArray = team.split('/')
+  if (stringArray.length !== 2) {
+    throw Error(`each team id needs to be given in 'org/team_slug'`)
+  }
+
+  const org = stringArray[0]
+  const teamSlug = stringArray[1]
+
+  let res
+  try {
+    res = await context.github.teams.listMembersInOrg({
+      org,
+      team_slug: teamSlug
+    })
+  } catch (err) {
+    if (err.status === 404) {
+      throw new TeamNotFoundError(team)
+    }
+    throw err
+  }
+
+  return res.data.map(member => member.login)
 }
 
 const findReviewersByState = (reviews, state) => {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "codecov": "^3.6.5",
+    "handlebars": "^4.7.6",
     "jest": "^24.0.0",
     "nock": "^11.7.2",
     "nodemon": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "lint": "standard --fix"
   },
   "dependencies": {
+    "colors": "^1.3.2",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.15",
+    "minimatch": "^3.0.4",
     "node-fetch": "^2.1.2",
-    "probot": "^9.6.6",
-    "probot-scheduler": "^2.0.0-beta.1",
-    "colors": "^1.3.2",
-    "minimatch": "^3.0.4"
+    "probot": "^9.11.3",
+    "probot-scheduler": "^2.0.0-beta.1"
   },
   "devDependencies": {
     "codecov": "^3.6.5",


### PR DESCRIPTION
Add the ability to limit the approval validator to team members
s
sample config:
```
- do: approvals
      min:
        count: 2 # Number of minimum reviewers. In this case 2.
        message: 'Custom message...'
      limit:
        teams: ['org/team_slug']  # when the option is present, only the approvals from the team members will count
```


closes #236 