### PR TITLE
fix: after validate

### DIFF
--- a/__tests__/unit/actions/comment.test.js
+++ b/__tests__/unit/actions/comment.test.js
@@ -19,7 +19,7 @@ test('check that comment created when afterValidate is called with proper parame
   const comment = new Comment()
   const context = createMockContext()
 
-  await comment.afterValidate(context, settings, result)
+  await comment.afterValidate(context, settings, '', result)
   expect(context.github.issues.createComment.mock.calls.length).toBe(1)
   expect(context.github.issues.createComment.mock.calls[0][0].body).toBe(`Your run has returned the following status: pass`)
 })
@@ -34,7 +34,7 @@ test('that comment is created three times when result contain three issues found
       pulls: []
     }
   }]
-  await comment.afterValidate(context, settings, result)
+  await comment.afterValidate(context, settings, '', result)
   expect(context.github.issues.createComment.mock.calls.length).toBe(3)
 })
 

--- a/lib/actions/assign.js
+++ b/lib/actions/assign.js
@@ -32,7 +32,7 @@ class Assign extends Action {
   // there is nothing to do
   async beforeValidate () {}
 
-  async afterValidate (context, settings, results) {
+  async afterValidate (context, settings, name, results) {
     const payload = this.getPayload(context)
     const issueNumber = payload.number
     const assignees = settings.assignees

--- a/lib/actions/close.js
+++ b/lib/actions/close.js
@@ -18,7 +18,7 @@ class Close extends Action {
   // there is nothing to do
   async beforeValidate () {}
 
-  async afterValidate (context, settings, results) {
+  async afterValidate (context, settings, name, results) {
     const payload = this.getPayload(context)
     const issueNumber = payload.number
 

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -17,10 +17,9 @@ class Comment extends Action {
     ]
   }
 
-  // there is nothing to do
   async beforeValidate () {}
 
-  async afterValidate (context, settings, results) {
+  async afterValidate (context, settings, name, results) {
     let scheduleResults = results.validationSuites && results.validationSuites[0].schedule
     let commentables = (scheduleResults)
       ? scheduleResults.issues.concat(scheduleResults.pulls)

--- a/lib/actions/labels.js
+++ b/lib/actions/labels.js
@@ -18,7 +18,7 @@ class Labels extends Action {
   // there is nothing to do
   async beforeValidate () {}
 
-  async afterValidate (context, settings, results) {
+  async afterValidate (context, settings, name, results) {
     const payload = this.getPayload(context)
     const issueNumber = payload.number
 

--- a/lib/actions/request_review.js
+++ b/lib/actions/request_review.js
@@ -24,7 +24,7 @@ class RequestReview extends Action {
   // there is nothing to do
   async beforeValidate () {}
 
-  async afterValidate (context, settings, results) {
+  async afterValidate (context, settings, name, results) {
     const payload = this.getPayload(context)
 
     let requestedReviewer = payload.requested_reviewers.map(reviewer => reviewer.login)


### PR DESCRIPTION
### Context
In the #297 , I accidentally left out parameter changes to afterValidate.
This had a small impact on `comment` action but, it is very low impact.