### PR TITLE
feat: delete old comments before creating new one

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,3 +18,6 @@ WEBHOOK_PROXY_URL=
 
 # Needed only for GitHub Enterprise deployments.
 GHE_HOST=
+
+# name of the GitHub App
+APP_NAME=

--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -142,6 +142,9 @@ module.exports = {
               resolve({ status: 204 })
             })
           },
+          listComments: () => {
+            return { data: (options.listComments) ? options.listComments : [] }
+          },
           addLabels: jest.fn(),
           update: jest.fn(),
           get: () => {

--- a/__tests__/unit/actions/comment.test.js
+++ b/__tests__/unit/actions/comment.test.js
@@ -19,6 +19,14 @@ test('check that comment created when afterValidate is called with proper parame
   const comment = new Comment()
   const context = createMockContext()
 
+  let result = {
+    status: 'pass',
+    validations: [{
+      status: 'pass',
+      name: 'Label'
+    }]
+  }
+
   await comment.afterValidate(context, settings, result)
   expect(context.github.issues.createComment.mock.calls.length).toBe(1)
   expect(context.github.issues.createComment.mock.calls[0][0].body).toBe(`Your run has returned the following status: pass`)
@@ -38,9 +46,76 @@ test('that comment is created three times when result contain three issues found
   expect(context.github.issues.createComment.mock.calls.length).toBe(3)
 })
 
-const createMockContext = () => {
-  let context = Helper.mockContext()
+test('check that old comments from Mergeable are deleted if they exists', async () => {
+  const comment = new Comment()
+
+  const listComments = [{
+    id: '1',
+    user: {
+      login: 'test-1'
+    }
+  },
+  {
+    id: '2',
+    user: {
+      login: 'Mergeable[bot]'
+    }
+  }]
+  const context = createMockContext(listComments)
+
+  let result = {
+    status: 'pass',
+    validations: [{
+      status: 'pass',
+      name: 'Label'
+    }]
+  }
+
+  await comment.afterValidate(context, settings, result)
+  expect(context.github.issues.deleteComment.mock.calls.length).toBe(1)
+  expect(context.github.issues.deleteComment.mock.calls[0][0].comment_id).toBe(`2`)
+})
+
+test('check that old_comment option works', async () => {
+  const comment = new Comment()
+
+  const settings = {
+    payload: {
+      body: `Your run has returned the following status: {{status}}`
+    },
+    old_comment: 'leave'
+  }
+
+  const listComments = [{
+    id: '1',
+    user: {
+      login: 'test-1'
+    }
+  },
+  {
+    id: '2',
+    user: {
+      login: 'Mergeable[bot]'
+    }
+  }]
+  const context = createMockContext(listComments)
+
+  let result = {
+    status: 'pass',
+    validations: [{
+      status: 'pass',
+      name: 'Label'
+    }]
+  }
+
+  await comment.afterValidate(context, settings, result)
+  expect(context.github.issues.deleteComment.mock.calls.length).toBe(0)
+})
+
+const createMockContext = (listComments) => {
+  let context = Helper.mockContext({listComments})
 
   context.github.issues.createComment = jest.fn()
+  context.github.issues.deleteComment = jest.fn()
   return context
 }

--- a/__tests__/unit/actions/comment.test.js
+++ b/__tests__/unit/actions/comment.test.js
@@ -71,19 +71,19 @@ test('check that old comments from Mergeable are deleted if they exists', async 
     }]
   }
 
-  await comment.afterValidate(context, settings, result)
+  await comment.afterValidate(context, settings, '', result)
   expect(context.github.issues.deleteComment.mock.calls.length).toBe(1)
   expect(context.github.issues.deleteComment.mock.calls[0][0].comment_id).toBe(`2`)
 })
 
-test('check that old_comment option works', async () => {
+test('check that leave_old_comment option works', async () => {
   const comment = new Comment()
 
   const settings = {
     payload: {
       body: `Your run has returned the following status: {{status}}`
     },
-    old_comment: 'leave'
+    leave_old_comment: true
   }
 
   const listComments = [{
@@ -108,7 +108,7 @@ test('check that old_comment option works', async () => {
     }]
   }
 
-  await comment.afterValidate(context, settings, result)
+  await comment.afterValidate(context, settings, '', result)
   expect(context.github.issues.deleteComment.mock.calls.length).toBe(0)
 })
 

--- a/docs/actions/comment.rst
+++ b/docs/actions/comment.rst
@@ -7,6 +7,7 @@ Comment
       payload:
         body: >
           Your very long comment can go here.
+      old_comment: 'delete' # delete by default, if you wish to leave the old comments use 'leave'
 
 Supported Events:
 ::

--- a/docs/actions/comment.rst
+++ b/docs/actions/comment.rst
@@ -7,7 +7,7 @@ Comment
       payload:
         body: >
           Your very long comment can go here.
-      old_comment: 'delete' # delete by default, if you wish to leave the old comments use 'leave'
+      leave_old_comment: true # Optional, by default old comments are deleted, if true, old comments will be left alone
 
 Supported Events:
 ::

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,8 @@
 CHANGELOG
 =====================================
 
+May 14, 2020 : Delete obsolete comments by default `#157 <https://github.com/mergeability/mergeable/issues/157>`_
+
 May 6, 2020 <Ability to create multiple checks with ``named`` recipe>
 
 May 5, 2020 <Added ability to configure config file name using ``CONFIG_PATH`` env variable>

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -12,7 +12,7 @@ const fetchCommentsByMergeable = async (context, issueNumber) => {
     context.repo({ issue_number: issueNumber })
   )
 
-  const botName = process.env.BOT_NAME ? process.env.BOT_NAME : 'Mergeable'
+  const botName = process.env.APP_NAME ? process.env.APP_NAME : 'Mergeable'
 
   return comments.data.filter(comment => comment.user.login === `${botName}[bot]`)
 }
@@ -21,7 +21,6 @@ const deleteOldComments = async (context, issueNumber) => {
   const oldComments = await fetchCommentsByMergeable(context, issueNumber)
 
   for (let comment of oldComments) {
-    console.log(comment)
     await context.github.issues.deleteComment(
       context.repo({ comment_id: comment.id })
     )
@@ -42,7 +41,7 @@ class Comment extends Action {
   async beforeValidate () {}
 
   async afterValidate (context, settings, name, results) {
-    if (settings.old_comment !== 'leave') {
+    if (!settings.leave_old_comment) {
       await deleteOldComments(context, this.getPayload(context).number)
     }
 

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -7,6 +7,27 @@ const createComment = async (context, issueNumber, body) => {
   )
 }
 
+const fetchCommentsByMergeable = async (context, issueNumber) => {
+  const comments = await context.github.issues.listComments(
+    context.repo({ issue_number: issueNumber })
+  )
+
+  const botName = process.env.BOT_NAME ? process.env.BOT_NAME : 'Mergeable'
+
+  return comments.data.filter(comment => comment.user.login === `${botName}[bot]`)
+}
+
+const deleteOldComments = async (context, issueNumber) => {
+  const oldComments = await fetchCommentsByMergeable(context, issueNumber)
+
+  for (let comment of oldComments) {
+    console.log(comment)
+    await context.github.issues.deleteComment(
+      context.repo({ comment_id: comment.id })
+    )
+  }
+}
+
 class Comment extends Action {
   constructor () {
     super('comment')
@@ -21,6 +42,10 @@ class Comment extends Action {
   async beforeValidate () {}
 
   async afterValidate (context, settings, results) {
+    if (settings.old_comment !== 'leave') {
+      await deleteOldComments(context, this.getPayload(context).number)
+    }
+
     let scheduleResults = results.validationSuites && results.validationSuites[0].schedule
     let commentables = (scheduleResults)
       ? scheduleResults.issues.concat(scheduleResults.pulls)


### PR DESCRIPTION
Old comments are removed by default before creating a new one on an issue

new config : 
```
    - do: comment
      payload:
        body: >
          Your very long comment can go here.
      old_comment: 'delete' # delete by default, if you wish to leave the old comments use 'leave'
```


closes #157 