### PR TITLE
feat: merge action

### DIFF
--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -117,6 +117,14 @@ module.exports = {
               }
             }
           },
+          checkIfMerged: async () => {
+            if (options.checkIfMerged === false) {
+              return throwNotFound()
+            } else {
+              return { status: 204 }
+            }
+          },
+          merge: jest.fn(),
           get: jest.fn()
         },
         paginate: jest.fn(async (fn, cb) => {

--- a/__tests__/unit/actions/merge.test.js
+++ b/__tests__/unit/actions/merge.test.js
@@ -1,0 +1,36 @@
+const Merge = require('../../../lib/actions/merge')
+const Helper = require('../../../__fixtures__/unit/helper')
+
+test('check that merge is called if PR has not been merged', async () => {
+  const merge = new Merge()
+  const checkIfMerged = false
+  const context = Helper.mockContext({ checkIfMerged })
+  const settings = {}
+
+  await merge.afterValidate(context, settings)
+  expect(context.github.pulls.merge.mock.calls.length).toBe(1)
+  expect(context.github.pulls.merge.mock.calls[0][0].merge_method).toBe('merge')
+})
+
+test('check that merge is not called if PR has not been merged', async () => {
+  const merge = new Merge()
+  const checkIfMerged = true
+  const context = Helper.mockContext({ checkIfMerged })
+  const settings = {}
+
+  await merge.afterValidate(context, settings)
+  expect(context.github.pulls.merge.mock.calls.length).toBe(0)
+})
+
+test('check that merge_method option works correctly', async () => {
+  const merge = new Merge()
+  const checkIfMerged = false
+  const context = Helper.mockContext({ checkIfMerged })
+  const settings = {
+    merge_method: 'squash'
+  }
+
+  await merge.afterValidate(context, settings)
+  expect(context.github.pulls.merge.mock.calls.length).toBe(1)
+  expect(context.github.pulls.merge.mock.calls[0][0].merge_method).toBe('squash')
+})

--- a/docs/actions/merge.rst
+++ b/docs/actions/merge.rst
@@ -1,0 +1,15 @@
+Merge
+^^^^^^^^
+
+::
+
+    - do: merge
+      merge_method: 'merge' # Optional , default is 'merge'. Other options : 'rebase', 'squash'
+
+.. warning::
+    ``merge`` action will not work currently as it require ``contents`` ``read:write`` permission which the mergeable doesn't have. We have plans to enable it in the near future
+
+Supported Events:
+::
+
+    'pull_request.*'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| May 30, 2020 : New Action `merge` added `#201 <https://github.com/mergeability/mergeable/issues/228>`_
 | May 29, 2020 : throw `UnSupportedSettingError` if provided setting is not valid `#228 <https://github.com/mergeability/mergeable/issues/228>`_
 | May 29, 2020 : Ability to Limit `stale` validator to certain days and time `#221 <https://github.com/mergeability/mergeable/issues/221>`_
 | May 23, 2020 : Allow PRs/Issues to be assigned to their author by using `@author` in the `assign` action

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -1,0 +1,52 @@
+const { Action } = require('./action')
+
+const checkIfMerged = async (context, prNumber) => {
+  let status = true
+
+  // return can be 204 or 404 only
+  try {
+    await context.github.pulls.checkIfMerged(
+      context.repo({ pull_number: prNumber })
+    )
+  } catch (err) {
+    if (err.status === 404) {
+      status = false
+    } else {
+      throw err
+    }
+  }
+
+  return status
+}
+
+class Comment extends Action {
+  constructor () {
+    super('merge')
+    this.supportedEvents = [
+      'pull_request.*'
+    ]
+  }
+
+  // there is nothing to do
+  async beforeValidate () {}
+
+  async afterValidate (context, settings, results) {
+    const prNumber = this.getPayload(context).number
+    const isMerged = await checkIfMerged(context, prNumber)
+
+    if (!isMerged) {
+      let mergeMethod = settings.merge_method ? settings.merge_method : 'merge'
+      try {
+        await context.github.pulls.merge(context.repo({ pull_number: prNumber, merge_method: mergeMethod }))
+      } catch (err) {
+        // skip on known errors
+        // 405 === Method not allowed , 409 === Conflict
+        if (!(err.status === 405 || err.status === 409)) {
+          throw err
+        }
+      }
+    }
+  }
+}
+
+module.exports = Comment

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -1,4 +1,7 @@
 const { Action } = require('./action')
+const UnSupportedSettingError = require('../errors/unSupportedSettingError')
+
+const MERGE_METHOD_OPTIONS = ['merge', 'rebase', 'squash']
 
 const checkIfMerged = async (context, prNumber) => {
   let status = true
@@ -25,6 +28,10 @@ class Merge extends Action {
     this.supportedEvents = [
       'pull_request.*'
     ]
+
+    this.supportedSettings = {
+      merge_method: 'string'
+    }
   }
 
   // there is nothing to do
@@ -35,13 +42,18 @@ class Merge extends Action {
     const isMerged = await checkIfMerged(context, prNumber)
 
     if (!isMerged) {
+      if (settings.merge_method && !MERGE_METHOD_OPTIONS.includes(settings.merge_method)) {
+        throw new UnSupportedSettingError(`Unknown Merge method, supported options are ${MERGE_METHOD_OPTIONS.join(', ')}`)
+      }
       let mergeMethod = settings.merge_method ? settings.merge_method : 'merge'
       try {
         await context.github.pulls.merge(context.repo({ pull_number: prNumber, merge_method: mergeMethod }))
       } catch (err) {
         // skip on known errors
         // 405 === Method not allowed , 409 === Conflict
-        if (!(err.status === 405 || err.status === 409)) {
+        if (err.status === 405 || err.status === 409) {
+          throw new Error(`Merge failed! error : err`)
+        } else {
           throw err
         }
       }

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -19,7 +19,7 @@ const checkIfMerged = async (context, prNumber) => {
   return status
 }
 
-class Comment extends Action {
+class Merge extends Action {
   constructor () {
     super('merge')
     this.supportedEvents = [
@@ -49,4 +49,4 @@ class Comment extends Action {
   }
 }
 
-module.exports = Comment
+module.exports = Merge


### PR DESCRIPTION
Context
Adds merge action 

example config 
```
    - do: merge
      merge_method: 'merge' # Optional , default is 'merge'. Other options : 'rebase', 'squash'
```
This feature does require more app permission so it won't work right now for mergeable

closes #201 
