### PR TITLE
feat: limit option for stale validator

### DIFF
--- a/__tests__/unit/validators/stale.test.js
+++ b/__tests__/unit/validators/stale.test.js
@@ -139,7 +139,7 @@ describe('limit option', () => {
     settings = {
       do: 'stale',
       days: 10,
-      limit: {
+      time_constraint: {
         time_zone: timeZone
       }
     }
@@ -153,7 +153,7 @@ describe('limit option', () => {
     let settings = {
       do: 'stale',
       days: 10,
-      limit: {
+      time_constraint: {
         days_of_week: ['Sun']
       }
     }
@@ -167,7 +167,7 @@ describe('limit option', () => {
     settings = {
       do: 'stale',
       days: 10,
-      limit: {
+      time_constraint: {
         days_of_week: ['Mon']
       }
     }
@@ -180,7 +180,7 @@ describe('limit option', () => {
     let settings = {
       do: 'stale',
       days: 10,
-      limit: {
+      time_constraint: {
         hours_between: ['7', '17']
       }
     }
@@ -194,7 +194,7 @@ describe('limit option', () => {
     settings = {
       do: 'stale',
       days: 10,
-      limit: {
+      time_constraint: {
         hours_between: ['9', '17']
       }
     }
@@ -205,7 +205,7 @@ describe('limit option', () => {
     settings = {
       do: 'stale',
       days: 10,
-      limit: {
+      time_constraint: {
         hours_between: ['1', '7']
       }
     }

--- a/__tests__/unit/validators/stale.test.js
+++ b/__tests__/unit/validators/stale.test.js
@@ -1,5 +1,15 @@
 const Helper = require('../../../__fixtures__/unit/helper')
 const Stale = require('../../../lib/validators/stale')
+const moment = require('moment-timezone')
+
+jest.mock('moment-timezone', () => jest.fn().mockReturnValue((({
+  utc: jest.fn().mockReturnValue(({
+    tz: jest.fn(),
+    day: jest.fn().mockReturnValue(1),
+    hour: jest.fn().mockReturnValue(8),
+    format: () => '2018–01–30T12:34:56+00:00'
+  }))
+}))))
 
 // Stale relies on the search api:
 // https://help.github.com/articles/searching-issues-and-pull-requests/#search-only-issues-or-pull-requests
@@ -106,6 +116,103 @@ test('will set the issues and pulls correctly when type is pull_request only', a
   context = createMockContext([])
   res = await stale.validate(context, settings)
   expect(res.status).toBe('fail')
+})
+
+describe('limit option', () => {
+  beforeEach(() => {
+
+  })
+
+  test('time_zone option works correctly', async () => {
+    const timeZone = 'America/Los_Angeles'
+    let settings = {
+      do: 'stale',
+      days: 10
+    }
+
+    let stale = new Stale()
+    let context = createMockContext([])
+
+    await stale.validate(context, settings)
+    expect(moment().utc().tz.mock.calls.length).toBe(0)
+
+    settings = {
+      do: 'stale',
+      days: 10,
+      limit: {
+        time_zone: timeZone
+      }
+    }
+
+    await stale.validate(context, settings)
+    expect(moment().utc().tz.mock.calls.length).toBe(1)
+    expect(moment().utc().tz.mock.calls[0][0]).toBe(timeZone)
+  })
+
+  test('days_of_week option works correctly', async () => {
+    let settings = {
+      do: 'stale',
+      days: 10,
+      limit: {
+        days_of_week: ['Sun']
+      }
+    }
+
+    let stale = new Stale()
+    let context = createMockContext([{ number: 1, pull_request: {} }])
+
+    let res = await stale.validate(context, settings)
+    expect(res.status).toBe('fail')
+
+    settings = {
+      do: 'stale',
+      days: 10,
+      limit: {
+        days_of_week: ['Mon']
+      }
+    }
+
+    res = await stale.validate(context, settings)
+    expect(res.status).toBe('pass')
+  })
+
+  test('hours_between option works correctly', async () => {
+    let settings = {
+      do: 'stale',
+      days: 10,
+      limit: {
+        hours_between: ['7', '17']
+      }
+    }
+
+    let stale = new Stale()
+    let context = createMockContext([{ number: 1, pull_request: {} }])
+
+    let res = await stale.validate(context, settings)
+    expect(res.status).toBe('pass')
+
+    settings = {
+      do: 'stale',
+      days: 10,
+      limit: {
+        hours_between: ['9', '17']
+      }
+    }
+
+    res = await stale.validate(context, settings)
+    expect(res.status).toBe('fail')
+
+    settings = {
+      do: 'stale',
+      days: 10,
+      limit: {
+        hours_between: ['1', '7']
+      }
+    }
+
+    res = await stale.validate(context, settings)
+    expect(res.status).toBe('fail')
+  })
 })
 
 const getFilteredParams = (context, filter = '', days = 10) => {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| May 21, 2020 : Ability to Limit `stale` validator to certain days and time `#221 <https://github.com/mergeability/mergeable/issues/221>`_
 | May 14, 2020 : Delete obsolete comments by default `#157 <https://github.com/mergeability/mergeable/issues/157>`_
 | May 12, 2020 : Limit so that only approval from team members will count, `#236 <https://github.com/mergeability/mergeable/issues/236>`_
 | May 6, 2020 : Ability to create multiple checks with ``named`` recipe, `#225 <https://github.com/mergeability/mergeable/issues/225>`_

--- a/docs/validators/stale.rst
+++ b/docs/validators/stale.rst
@@ -6,7 +6,7 @@ Stale
     - do: stale
       days: 20 # number of days ago.
       type: pull_request, issues # what items to search for.
-      limit: # Optional, run only if the specific options are met
+      time_constraint: # Optional, run the validator only if it in within the time constraint
         time_zone: 'America/Los_Angeles' # Optional, UTC time by default, for valid timezones see `here <https://momentjs.com/timezone/>`_
         hours_between: ['9', '17'] # Optional, 24 hours by default, run only if [0] >= Hour Now <= [1]
         days_of_Week: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'] # Optional, 7 days a week by default, specific the days of the week in which to run the validator

--- a/docs/validators/stale.rst
+++ b/docs/validators/stale.rst
@@ -4,8 +4,12 @@ Stale
 ::
 
     - do: stale
-    days: 20 # number of days ago.
-    type: pull_request, issues # what items to search for.
+      days: 20 # number of days ago.
+      type: pull_request, issues # what items to search for.
+      limit: # Optional, run only if the specific options are met
+        time_zone: 'America/Los_Angeles' # Optional, UTC time by default, for valid timezones see `here <https://momentjs.com/timezone/>`_
+        hours_between: ['9', '17'] # Optional, 24 hours by default, run only if [0] >= Hour Now <= [1]
+        days_of_Week: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'] # Optional, 7 days a week by default, specific the days of the week in which to run the validator
 
 .. note::
     This is a special use case. The schedule event runs on an interval. When used with stale, it will search for issues and/or pull request that are n days old. See a full example »
@@ -13,4 +17,4 @@ Stale
 Supported Events:
 ::
 
-    'pull_request.*', 'pull_request_review.*', 'issues.*'
+    'schedule.repository'

--- a/lib/validators/stale.js
+++ b/lib/validators/stale.js
@@ -23,15 +23,15 @@ class Stale extends Validator {
   }
 
   async validate (context, validationSettings) {
-    if (validationSettings.limit) {
-      const limitOptions = validationSettings.limit
+    if (validationSettings.time_constraint) {
+      const timeOptions = validationSettings.time_constraint
       const now = moment().utc(false)
 
-      if (limitOptions.time_zone) now.tz(limitOptions.time_zone)
-      if (limitOptions.days_of_week && !limitOptions.days_of_week.includes(dayOfTheWeek[now.day()])) return craftFailOutput(validationSettings)
-      if (limitOptions.hours_between && limitOptions.hours_between.length === 2) {
+      if (timeOptions.time_zone) now.tz(timeOptions.time_zone)
+      if (timeOptions.days_of_week && !timeOptions.days_of_week.includes(dayOfTheWeek[now.day()])) return craftFailOutput(validationSettings)
+      if (timeOptions.hours_between && timeOptions.hours_between.length === 2) {
         const hourNow = now.hour()
-        if (hourNow < limitOptions.hours_between[0] || hourNow > limitOptions.hours_between[1]) return craftFailOutput(validationSettings)
+        if (hourNow < timeOptions.hours_between[0] || hourNow > timeOptions.hours_between[1]) return craftFailOutput(validationSettings)
       }
     }
 

--- a/lib/validators/stale.js
+++ b/lib/validators/stale.js
@@ -1,5 +1,16 @@
 const { Validator } = require('./validator')
 const constructOutput = require('./options_processor/options/lib/constructOutput')
+const moment = require('moment-timezone')
+
+const dayOfTheWeek = [
+  'Sun',
+  'Mon',
+  'Tue',
+  'Wed',
+  'Thu',
+  'Fri',
+  'Sat'
+]
 
 const MAX_ISSUES = 20 // max issues to retrieve each time.
 
@@ -12,6 +23,18 @@ class Stale extends Validator {
   }
 
   async validate (context, validationSettings) {
+    if (validationSettings.limit) {
+      const limitOptions = validationSettings.limit
+      const now = moment().utc(false)
+
+      if (limitOptions.time_zone) now.tz(limitOptions.time_zone)
+      if (limitOptions.days_of_week && !limitOptions.days_of_week.includes(dayOfTheWeek[now.day()])) return craftFailOutput(validationSettings)
+      if (limitOptions.hours_between && limitOptions.hours_between.length === 2) {
+        const hourNow = now.hour()
+        if (hourNow < limitOptions.hours_between[0] || hourNow > limitOptions.hours_between[1]) return craftFailOutput(validationSettings)
+      }
+    }
+
     let days = validationSettings.days || 20
     let typeSetting = validationSettings.type || ['issue', 'pr']
     let types = Array.isArray(typeSetting) &&
@@ -42,6 +65,19 @@ class Stale extends Validator {
     }
 
     return getResult(scheduleResult, { days: days, types: types }, validationSettings)
+  }
+}
+
+const craftFailOutput = (validationSettings) => {
+  return {
+    status: 'fail',
+    name: 'stale',
+    validations: constructOutput(
+      'stale',
+      'fail',
+      validationSettings,
+      validationSettings
+    )
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.15",
     "minimatch": "^3.0.4",
+    "moment-timezone": "^0.5.31",
     "node-fetch": "^2.1.2",
     "probot": "^9.11.3",
     "probot-scheduler": "^2.0.0-beta.1"


### PR DESCRIPTION
Context
allow stale to only run if certain conditions are met
```
    - do: stale
      days: 20 # number of days ago.
      type: pull_request, issues # what items to search for.
      limit: # Optional, run only if the specific options are met
        time_zone: 'America/Los_Angeles' # Optional, UTC time by default, for valid timezones see `here <https://momentjs.com/timezone/>`_
        hours_between: ['9', '17'] # Optional, 24 hours by default, run only if [0] >= Hour Now <= [1]
        days_of_Week: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'] # Optional, 7 days a week by default, specific the days of the week in which to run the validator
```

closes #221 