### PR TITLE
feat: fill in missing param for `checks` by using default values

### DIFF
--- a/__tests__/unit/configuration/transformers/v2Config.test.js
+++ b/__tests__/unit/configuration/transformers/v2Config.test.js
@@ -110,7 +110,7 @@ test('only pass, fail defaults ignore recipes that are not for pull_requests', (
   expect(transformed.mergeable[0].error).toEqual([])
 })
 
-test('default checks fill in missing fields', () => {
+test('default checks fill in missing required fields', () => {
   let config = `
   version: 2
   mergeable:
@@ -130,7 +130,6 @@ test('default checks fill in missing fields', () => {
 
   expect(transformed.mergeable[0].pass).toEqual([{
     do: 'checks',
-    state: 'completed',
     status: 'success',
     payload: {
       title: 'Mergeable Run has been Completed!',

--- a/__tests__/unit/configuration/transformers/v2Config.test.js
+++ b/__tests__/unit/configuration/transformers/v2Config.test.js
@@ -109,3 +109,56 @@ test('only pass, fail defaults ignore recipes that are not for pull_requests', (
   expect(transformed.mergeable[0].fail).toEqual([])
   expect(transformed.mergeable[0].error).toEqual([])
 })
+
+test('default checks fill in missing fields', () => {
+  let config = `
+  version: 2
+  mergeable:
+    - when: pull_requests.*
+      validate:
+        - do: title
+          must_exclude:
+            regex: 'wip|work in progress'
+            message: 'This PR is work in progress.'
+      pass:
+        - do: checks
+          payload:
+            summary: 'test Summary'
+            text: 'test text'
+  `
+  let transformed = V2Config.transform(yaml.safeLoad(config))
+
+  expect(transformed.mergeable[0].pass).toEqual([{
+    do: 'checks',
+    state: 'completed',
+    status: 'success',
+    payload: {
+      title: 'Mergeable Run has been Completed!',
+      summary: 'test Summary',
+      text: 'test text'
+    }
+  }])
+})
+
+test('adding default only works for checks', () => {
+  let config = `
+  version: 2
+  mergeable:
+    - when: pull_requests.*
+      validate:
+        - do: title
+          must_exclude:
+            regex: 'wip|work in progress'
+            message: 'This PR is work in progress.'
+      fail:
+        - do: comment
+          payload:
+            body: 'test Body'
+  `
+  let transformed = V2Config.transform(yaml.safeLoad(config))
+
+  expect(transformed.mergeable[0].fail).toEqual([{do: 'comment',
+    payload: {
+      body: 'test Body'
+    }}])
+})

--- a/docs/actions/check.rst
+++ b/docs/actions/check.rst
@@ -60,8 +60,11 @@ You can pass in Handlebars template to show the details result of the run.
                    {{/each}}
             {{/each}}"
 
+.. note::
+    if any of required fields ``title``, ``summary`` or ``status`` is missing, default values will be used
+
 .. warning::
-    if you have have ``checks`` action only for some of the result, you may end up in a state where checks are never finished.
+    if you have have ``checks`` action only for some of the outcome, you may end up in a state where checks are never finished.
     So be sure to have ``checks`` for all outcome (``pass``, ``fail``, and ``error``)
 
 Supported Events:

--- a/docs/actions/check.rst
+++ b/docs/actions/check.rst
@@ -35,6 +35,35 @@ You can pass in Handlebars template to show the details result of the run.
                      {{/each}}\n
               {{/each}}"
 
+::
+
+    - do: checks # default error case
+      status: 'action_required' # Can be: success, failure, neutral, cancelled, timed_out, or action_required
+      payload:
+        title: 'Mergeable found some errors!'
+        summary: |
+            ### Status: {{toUpperCase validationStatus}}
+            Some or All of the validators have returned 'error' status, please check below for details
+            Here are some stats of the run: \n {{validationCount}} validations were ran.
+            {{passCount}} ***PASSED***
+            {{failCount}} ***FAILED***
+            {{errorCount}} ***ERRORED***
+        text: "{{#each validationSuites}}
+            #### {{{statusIcon status}}} Validator: {{toUpperCase name}}
+            Status {{toUpperCase status}}
+            {{#each validations }} * {{{statusIcon status}}} ***{{{ description }}}***
+                   Input : {{{details.input}}}
+                   Settings : {{{displaySettings details.settings}}}
+                   {{#if details.error}}
+                   Error : {{{details.error}}}
+                   {{/if}}
+                   {{/each}}
+            {{/each}}"
+
+.. warning::
+    if you have have ``checks`` action only for some of the result, you may end up in a state where checks are never finished.
+    So be sure to have ``checks`` for all outcome (``pass``, ``fail``, and ``error``)
+
 Supported Events:
 ::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| May 21, 2020 : For missing fields in 'checks', default values will be used `#233 <https://github.com/mergeability/mergeable/issues/233#issuecomment-632211789>`_
 | May 14, 2020 : Delete obsolete comments by default `#157 <https://github.com/mergeability/mergeable/issues/157>`_
 | May 12, 2020 : Limit so that only approval from team members will count, `#236 <https://github.com/mergeability/mergeable/issues/236>`_
 | May 6, 2020 : Ability to create multiple checks with ``named`` recipe, `#225 <https://github.com/mergeability/mergeable/issues/225>`_

--- a/lib/configuration/lib/consts.js
+++ b/lib/configuration/lib/consts.js
@@ -38,8 +38,12 @@ module.exports = {
     status: 'action_required',
     payload: {
       title: 'Mergeable found some failed checks!',
-      summary: `Some or All of the validators have returned 'error' status, please check below for details
-      Here are some stats of the run: \n {{validationCount}} validations were ran. \n {{passCount}} ***PASSED***
+      summary: `### Status: {{toUpperCase validationStatus}}
+      Some or All of the validators have returned 'error' status, please check below for details
+      
+      Here are some stats of the run: 
+      {{validationCount}} validations were ran. 
+      {{passCount}} ***PASSED***
       {{failCount}} ***FAILED***
       {{errorCount}} ***ERRORED***`,
       text: `{{#each validationSuites}}

--- a/lib/configuration/transformers/v2Config.js
+++ b/lib/configuration/transformers/v2Config.js
@@ -15,8 +15,14 @@ const checkAndSetDefault = (ruleSet, defaultValue) => {
   } else {
     return ruleSet.map(rule => {
       if (rule.do === 'checks') {
-        const newRule = Object.assign({}, defaultValue[0], rule)
-        newRule.payload = Object.assign({}, defaultValue[0].payload, rule.payload)
+        const newRule = _.cloneDeep(rule)
+        if (_.isUndefined(newRule.status)) newRule.status = defaultValue[0].status
+        if (_.isUndefined(newRule.payload)) {
+          newRule.payload = defaultValue[0].payload
+        } else {
+          if (_.isUndefined(newRule.payload.title)) newRule.payload.title = defaultValue[0].payload.title
+          if (_.isUndefined(newRule.payload.summary)) newRule.payload.summary = defaultValue[0].payload.summary
+        }
         return newRule
       }
 

--- a/lib/configuration/transformers/v2Config.js
+++ b/lib/configuration/transformers/v2Config.js
@@ -9,18 +9,28 @@ class V2Config {
   }
 }
 
+const checkAndSetDefault = (ruleSet, defaultValue) => {
+  if (ruleSet === undefined) {
+    return defaultValue
+  } else {
+    return ruleSet.map(rule => {
+      if (rule.do === 'checks') {
+        const newRule = Object.assign({}, defaultValue[0], rule)
+        newRule.payload = Object.assign({}, defaultValue[0].payload, rule.payload)
+        return newRule
+      }
+
+      return rule
+    })
+  }
+}
+
 const setPullRequestDefault = (config) => {
   config.mergeable.forEach((recipe) => {
     if (recipe.when.includes('pull_request')) {
-      if (recipe.pass === undefined) {
-        recipe.pass = consts.DEFAULT_PR_PASS
-      }
-      if (recipe.fail === undefined) {
-        recipe.fail = consts.DEFAULT_PR_FAIL
-      }
-      if (recipe.error === undefined) {
-        recipe.error = consts.DEFAULT_PR_ERROR
-      }
+      recipe.pass = checkAndSetDefault(recipe.pass, consts.DEFAULT_PR_PASS)
+      recipe.fail = checkAndSetDefault(recipe.fail, consts.DEFAULT_PR_FAIL)
+      recipe.error = checkAndSetDefault(recipe.error, consts.DEFAULT_PR_ERROR)
     } else {
       if (recipe.pass === undefined) {
         recipe.pass = []


### PR DESCRIPTION
Context

When user provide partial parameter list for checks option, fill in the rest using default values

for more context, see https://github.com/mergeability/mergeable/issues/233#issuecomment-632211789