### PR TITLE
feat: assign PR/Issue to author

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Supported events:
 
 ```yml
 - do: assign
-  assignees: [ 'shine2lay', 'jusx' ] # only array accepted
+  assignees: [ 'shine2lay', 'jusx', '@author' ] # only array accepted, use @author for PR/Issue author
 ```
 
 Supported events:

--- a/__tests__/unit/actions/assign.test.js
+++ b/__tests__/unit/actions/assign.test.js
@@ -15,6 +15,19 @@ test('check that assignees are added when afterValidate is called with proper pa
   expect(context.github.issues.addAssignees.mock.calls[0][0].assignees[1]).toBe(`testuser2`)
 })
 
+test('check that creator is added when assignee is @author', async () => {
+  const settings = {
+    assignees: [ '@author' ]
+  }
+
+  const comment = new Assign()
+  const context = createMockContext()
+
+  await comment.afterValidate(context, settings)
+  expect(context.github.issues.addAssignees.mock.calls.length).toBe(1)
+  expect(context.github.issues.addAssignees.mock.calls[0][0].assignees[0]).toBe(`creator`)
+})
+
 test('check only authorized users are added as assignee ', async () => {
   const settings = {
     assignees: ['testuser1', 'testuser2']

--- a/docs/actions/assign.rst
+++ b/docs/actions/assign.rst
@@ -4,7 +4,7 @@ Assign
 ::
 
     - do: assign
-      assignees: [ 'shine2lay', 'jusx' ] # only array accepted
+      assignees: [ 'shine2lay', 'jusx', '@author' ] # only array accepted, use @author for PR/Issue author
 
 Supported Events:
 ::

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| May 23, 2020 : Allow PRs/Issues to be assigned to their author by using `@author` in the `assign` action
 | May 14, 2020 : Delete obsolete comments by default `#157 <https://github.com/mergeability/mergeable/issues/157>`_
 | May 12, 2020 : Limit so that only approval from team members will count, `#236 <https://github.com/mergeability/mergeable/issues/236>`_
 | May 6, 2020 : Ability to create multiple checks with ``named`` recipe, `#225 <https://github.com/mergeability/mergeable/issues/225>`_

--- a/lib/actions/assign.js
+++ b/lib/actions/assign.js
@@ -20,6 +20,13 @@ const checkAssignee = async (context, issueNumber, assignee) => {
   return isValidAssignee(checkResult) ? assignee : null
 }
 
+const mapSpecialAssignee = async (payload, assignee) => {
+  if (assignee.toLowerCase() === '@author') {
+    return payload.user.login
+  }
+  return assignee
+}
+
 class Assign extends Action {
   constructor () {
     super('assign')
@@ -35,7 +42,7 @@ class Assign extends Action {
   async afterValidate (context, settings, name, results) {
     const payload = this.getPayload(context)
     const issueNumber = payload.number
-    const assignees = settings.assignees
+    const assignees = await Promise.all(settings.assignees.map(assignee => mapSpecialAssignee(payload, assignee)))
     const checkResults = await Promise.all(assignees.map(assignee => checkAssignee(context, issueNumber, assignee)))
 
     const authorizedAssignees = checkResults.filter(assignee => assignee !== null)

--- a/lib/actions/assign.js
+++ b/lib/actions/assign.js
@@ -20,7 +20,7 @@ const checkAssignee = async (context, issueNumber, assignee) => {
   return isValidAssignee(checkResult) ? assignee : null
 }
 
-const mapSpecialAssignee = async (payload, assignee) => {
+const mapSpecialAssignee = (payload, assignee) => {
   if (assignee.toLowerCase() === '@author') {
     return payload.user.login
   }
@@ -42,7 +42,7 @@ class Assign extends Action {
   async afterValidate (context, settings, name, results) {
     const payload = this.getPayload(context)
     const issueNumber = payload.number
-    const assignees = await Promise.all(settings.assignees.map(assignee => mapSpecialAssignee(payload, assignee)))
+    const assignees = settings.assignees.map(assignee => mapSpecialAssignee(payload, assignee))
     const checkResults = await Promise.all(assignees.map(assignee => checkAssignee(context, issueNumber, assignee)))
 
     const authorizedAssignees = checkResults.filter(assignee => assignee !== null)


### PR DESCRIPTION
**Usecase:** As a user I want to be able to automatically assign a PR/Issue not only to a predefined person but also to the author of the PR/Issue.

**Solution:** Besides allowing a fixed list of assignees one should be able to put in a placeholder like `@author` to assign the PR/Issue to the creator

**Sample usage:**
```yaml
version: 2
mergeable:
  - when: pull_request.*, issues.*
    name: 'Auto assign to author if no assignee is set'
    validate:
      - do: assignee
        min:
          count: 1
    fail:
      - do: assign
        assignees: [ '@author' ]
```

**Remark:** I have no hard feelings about the placeholder name, I just used `@author` because the `@` is never part of a github username