### PR TITLE
fix: Correcting schedule interval

### DIFF
--- a/__tests__/unit/mergeable.test.js
+++ b/__tests__/unit/mergeable.test.js
@@ -3,7 +3,7 @@ const {Mergeable} = require('../../lib/mergeable')
 describe('Mergeable', () => {
   test('starting in dev mode and flexed correctly', async () => {
     let mergeable = startMergeable('development')
-    expect(mergeable.schedule).toBeCalledWith(mockRobot, { interval: 60 * 60 * 2 })
+    expect(mergeable.schedule).toBeCalledWith(mockRobot, { interval: 2000 })
     expect(mergeable.flex).toHaveBeenCalledTimes(1)
   })
 

--- a/lib/mergeable.js
+++ b/lib/mergeable.js
@@ -56,17 +56,17 @@ class Mergeable {
 
   start (robot) {
     let log = logger.create('mergeable')
-    let intervalSecs = 2
+    let scheduleIntervalSeconds = 2
     if (this.mode === 'development') {
       log.info('In DEVELOPMENT mode.')
     } else {
       log.info('In PRODUCTION mode.')
-      intervalSecs = 1000
+      scheduleIntervalSeconds = 3600
     }
 
     if (process.env.MERGEABLE_SCHEDULER === 'true') {
-      log.info('Starting scheduler at ' + intervalSecs + ' second intervals.')
-      this.schedule(robot, { interval: 60 * 60 * intervalSecs })
+      log.info('Starting scheduler at ' + scheduleIntervalSeconds + ' second intervals.')
+      this.schedule(robot, { interval: scheduleIntervalSeconds * 1000 })
     } else {
       log.info(`Scheduler: ${'off'.bold.white}!`)
     }


### PR DESCRIPTION
This PR corrects the time confusion in scheduler. [Probot scheduler](https://github.com/probot/scheduler) takes miliseconds as trigger interval, but in the code this is mixed with seconds and it's not really clear. It's documented that scheduler runs every 2 seconds in dev mode, but in reality it runs every `60 * 60 * 2` miliseconds which is `7.2` seconds