### PR TITLE
fix: `size` ignore supported settings

### DIFF
--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -24,7 +24,7 @@ class Size extends Validator {
       'pull_request.synchronize'
     ]
     this.supportedSettings = {
-      ignore: Array,
+      ignore: 'array',
       lines: {
         max: {
           count: 'number',


### PR DESCRIPTION
Context
there was a typo the `size` validator's supported settings


closes #313 