### PR TITLE
fix: commit validator supported Settings

### DIFF
--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -11,7 +11,7 @@ const DEFAULT_SUCCESS_MESSAGE = `Your commit messages met the specified criteria
 
 class Commit extends Validator {
   constructor () {
-    super('dependent')
+    super('commit')
     this.supportedEvents = [
       'pull_request.*',
       'pull_request_review.*'
@@ -19,6 +19,7 @@ class Commit extends Validator {
     this.supportedSettings = {
       message: {
         regex: 'string',
+        regex_flag: 'string',
         message: 'string',
         skip_merge: 'boolean',
         oldest_only: 'boolean',


### PR DESCRIPTION
Context

commit validator name had a typo + supported setting is missing `regex_flag` variable