### PR TITLE
fix: test supported settings

### DIFF
--- a/__tests__/unit/validators/and.test.js
+++ b/__tests__/unit/validators/and.test.js
@@ -21,7 +21,7 @@ describe('And Validator Unit Test', () => {
         }
       ]
     }
-    let validation = await and.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('fail')
   })
 
@@ -44,7 +44,7 @@ describe('And Validator Unit Test', () => {
         }
       ]
     }
-    let validation = await and.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('fail')
   })
 
@@ -67,7 +67,7 @@ describe('And Validator Unit Test', () => {
         }
       ]
     }
-    let validation = await and.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('pass')
   })
 
@@ -76,7 +76,7 @@ describe('And Validator Unit Test', () => {
     const settings = {
       do: 'and'
     }
-    let validation = await and.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 
@@ -86,7 +86,7 @@ describe('And Validator Unit Test', () => {
       do: 'and',
       validate: ''
     }
-    let validation = await and.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 
@@ -96,7 +96,7 @@ describe('And Validator Unit Test', () => {
       do: 'and',
       validate: []
     }
-    let validation = await and.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 
@@ -108,7 +108,7 @@ describe('And Validator Unit Test', () => {
         { do: 'missing' }
       ]
     }
-    let validation = await and.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 
@@ -143,7 +143,7 @@ describe('And Validator Unit Test', () => {
       ]
     }
 
-    let validation = await and.validate(createMockContext({title: 'Version 2'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 2'}), settings, registry)
     expect(validation.status).toBe('fail')
   })
 
@@ -178,7 +178,7 @@ describe('And Validator Unit Test', () => {
       ]
     }
 
-    let validation = await and.validate(createMockContext({title: 'Version 2'}), settings, registry)
+    let validation = await and.processValidate(createMockContext({title: 'Version 2'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 })

--- a/__tests__/unit/validators/assignee.test.js
+++ b/__tests__/unit/validators/assignee.test.js
@@ -11,7 +11,7 @@ test('that mergeable is false when less than minimum', async () => {
     }
   }
 
-  let validation = await assignee.validate(createMockPR(1), settings)
+  let validation = await assignee.processValidate(createMockPR(1), settings)
   expect(validation.status).toBe('fail')
 })
 
@@ -24,7 +24,7 @@ test('that mergeable is true when the same as minimum', async () => {
       count: 2
     }
   }
-  let validation = await assignee.validate(createMockPR(2), settings)
+  let validation = await assignee.processValidate(createMockPR(2), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -37,7 +37,7 @@ test('that mergeable is true when greater than minimum', async () => {
       count: 2
     }
   }
-  let validation = await assignee.validate(createMockPR(3), settings)
+  let validation = await assignee.processValidate(createMockPR(3), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -50,7 +50,7 @@ test('that description is dynamic based on minimum', async () => {
       count: 5
     }
   }
-  let validation = await assignee.validate(createMockPR(1), settings)
+  let validation = await assignee.processValidate(createMockPR(1), settings)
   expect(validation.validations[0].description).toBe('assignee count is less than "5"')
 })
 
@@ -63,7 +63,7 @@ test('that description is correct when mergeable', async () => {
       count: 5
     }
   }
-  let validation = await assignee.validate(createMockPR(5), settings)
+  let validation = await assignee.processValidate(createMockPR(5), settings)
   expect(validation.validations[0].description).toBe("assignee does have a minimum of '5'")
 })
 
@@ -77,11 +77,11 @@ test('checks that max is working', async () => {
     }
   }
 
-  let validation = await assignee.validate(createMockPR(3), settings)
+  let validation = await assignee.processValidate(createMockPR(3), settings)
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe('assignee count is more than "2"')
 
-  validation = await assignee.validate(createMockPR(2), settings)
+  validation = await assignee.processValidate(createMockPR(2), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -96,11 +96,11 @@ test('checks that advance_setting message is working', async () => {
     }
   }
 
-  let validation = await assignee.validate(createMockPR(3), settings)
+  let validation = await assignee.processValidate(createMockPR(3), settings)
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe('test string')
 
-  validation = await assignee.validate(createMockPR(2), settings)
+  validation = await assignee.processValidate(createMockPR(2), settings)
   expect(validation.status).toBe('pass')
 })
 

--- a/__tests__/unit/validators/changeset.test.js
+++ b/__tests__/unit/validators/changeset.test.js
@@ -11,10 +11,10 @@ test('validate returns correctly', async () => {
 
   }
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  let validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
   expect(validation.status).toBe('pass')
 
-  validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'b.js']), settings)
+  validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'b.js']), settings)
   expect(validation.status).toBe('fail')
 })
 
@@ -28,7 +28,7 @@ test('fail gracefully if invalid regex', async () => {
 
   }
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  let validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
   expect(validation.status).toBe('fail')
 })
 
@@ -41,7 +41,7 @@ test('mergeable is true if must_include is one of the label', async () => {
     }
   }
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js', 'a.jsx']), settings)
+  let validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js', 'a.jsx']), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -54,7 +54,7 @@ test('mergeable is false if must_exclude is one of the label', async () => {
     }
   }
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  let validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
   expect(validation.status).toBe('fail')
 })
 
@@ -67,7 +67,7 @@ test('that it validates ends_with correctly', async () => {
     }
   }
 
-  let validation = await changeset.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  let validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
   expect(validation.status).toBe('pass')
 })
 

--- a/__tests__/unit/validators/commit.test.js
+++ b/__tests__/unit/validators/commit.test.js
@@ -29,12 +29,12 @@ test('validate returns correctly', async () => {
     }
   ]
 
-  let validation = await commit.validate(createMockContext(commits), settings)
+  let validation = await commit.processValidate(createMockContext(commits), settings)
   expect(validation.status).toBe('fail')
 
   commits[0].commit.message = 'feat: this'
 
-  validation = await commit.validate(createMockContext(commits), settings)
+  validation = await commit.processValidate(createMockContext(commits), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -67,12 +67,12 @@ test('oldest_only sub option', async () => {
     }
   ]
 
-  let validation = await commit.validate(createMockContext(commits), settings)
+  let validation = await commit.processValidate(createMockContext(commits), settings)
   expect(validation.status).toBe('fail')
 
   commits[0].commit.message = 'feat: this'
 
-  validation = await commit.validate(createMockContext(commits), settings)
+  validation = await commit.processValidate(createMockContext(commits), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -105,11 +105,11 @@ test('skip_merge sub option', async () => {
     }
   ]
 
-  let validation = await commit.validate(createMockContext(commits), settings)
+  let validation = await commit.processValidate(createMockContext(commits), settings)
   expect(validation.status).toBe('fail')
 
   settings.message.skip_merge = true
-  validation = await commit.validate(createMockContext(commits), settings)
+  validation = await commit.processValidate(createMockContext(commits), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -142,12 +142,12 @@ test('single_commit_only sub option', async () => {
     }
   ]
 
-  let validation = await commit.validate(createMockContext(commits), settings)
+  let validation = await commit.processValidate(createMockContext(commits), settings)
   expect(validation.status).toBe('pass')
   expect(validation.validations[0].description).toBe('Since there are more than one commits, Skipping validation')
 
   commits.pop()
-  validation = await commit.validate(createMockContext(commits), settings)
+  validation = await commit.processValidate(createMockContext(commits), settings)
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe('Some or all of your commit messages doesn\'t meet the criteria')
 })

--- a/__tests__/unit/validators/dependent.test.js
+++ b/__tests__/unit/validators/dependent.test.js
@@ -13,12 +13,12 @@ describe('dependent files with modified', () => {
 
     }
 
-    let validation = await dependent.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+    let validation = await dependent.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
     expect(validation.status).toBe('pass')
 
     // test with only requiring one dependent file.
     settings.changed.files = ['package-lock.json']
-    validation = await dependent.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+    validation = await dependent.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
     expect(validation.status).toBe('pass')
   })
 
@@ -32,7 +32,7 @@ describe('dependent files with modified', () => {
       }
     }
 
-    let validation = await dependent.validate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
+    let validation = await dependent.processValidate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
     expect(validation.status).toBe('fail')
   })
 
@@ -46,7 +46,7 @@ describe('dependent files with modified', () => {
       }
     }
 
-    let validation = await dependent.validate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
+    let validation = await dependent.processValidate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
     expect(validation.status).toBe('fail')
   })
 
@@ -60,7 +60,7 @@ describe('dependent files with modified', () => {
       }
     }
 
-    let validation = await dependent.validate(createMockContext([]), settings)
+    let validation = await dependent.processValidate(createMockContext([]), settings)
     expect(validation.status).toBe('pass')
   })
 
@@ -73,7 +73,7 @@ describe('dependent files with modified', () => {
       }
     }
 
-    let validation = await dependent.validate(createMockContext([]), settings)
+    let validation = await dependent.processValidate(createMockContext([]), settings)
     expect(validation.status).toBe('error')
     expect(validation.validations[0].description).toBe('Failed to validate because the \'file\' sub option for \'changed\' option is missing. Please check the documentation')
   })
@@ -88,13 +88,13 @@ describe('dependent files with modified', () => {
       }
     }
 
-    let validation = await dependent.validate(createMockContext(['a.js']), settings)
+    let validation = await dependent.processValidate(createMockContext(['a.js']), settings)
     expect(validation.status).toBe('fail')
 
-    validation = await dependent.validate(createMockContext(['test/test.js']), settings)
+    validation = await dependent.processValidate(createMockContext(['test/test.js']), settings)
     expect(validation.status).toBe('fail')
 
-    validation = await dependent.validate(createMockContext(['test/test.js', 'package-lock.json']), settings)
+    validation = await dependent.processValidate(createMockContext(['test/test.js', 'package-lock.json']), settings)
     expect(validation.status).toBe('pass')
   })
 })
@@ -106,7 +106,7 @@ test('that mergeable is true if none of the dependent file is modified', async (
     files: ['a.js', 'b.go']
   }
 
-  let validation = await dependent.validate(createMockContext([]), settings)
+  let validation = await dependent.processValidate(createMockContext([]), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -117,7 +117,7 @@ test('that mergeable is true if all of the dependent file is modified', async ()
     files: ['package.json', 'yarn.lock']
   }
 
-  let validation = await dependent.validate(createMockContext(['package.json', 'yarn.lock', 'a.js']), settings)
+  let validation = await dependent.processValidate(createMockContext(['package.json', 'yarn.lock', 'a.js']), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -128,7 +128,7 @@ test('that mergeable is true if one of the dependent file is added', async () =>
     files: ['package.json', 'yarn.lock']
   }
 
-  let validation = await dependent.validate(
+  let validation = await dependent.processValidate(
     createMockContext([
       { filename: 'package.json', status: 'added' },
       { filename: 'yarn.lock', status: 'modified' }
@@ -145,7 +145,7 @@ test('that mergeable is false when only one of the dependent file is added', asy
     files: ['package.json', 'yarn.lock']
   }
 
-  let validation = await dependent.validate(
+  let validation = await dependent.processValidate(
     createMockContext([{ filename: 'package.json', status: 'added' }]),
     settings
   )
@@ -159,7 +159,7 @@ test('that mergeable is false when only some of the dependent files are modified
     files: ['package.json', 'yarn.lock']
   }
 
-  let validation = await dependent.validate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
+  let validation = await dependent.processValidate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
   expect(validation.status).toBe('fail')
 })
 
@@ -172,7 +172,7 @@ test('test description is correct', async () => {
 
   let defaultMessage = 'One or more files (yarn.lock) are missing from your pull request because they are dependent on the following: package.json'
 
-  let validation = await dependent.validate(createMockContext(['package.json']), settings)
+  let validation = await dependent.processValidate(createMockContext(['package.json']), settings)
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe(defaultMessage)
 })
@@ -187,7 +187,7 @@ test('test that custom message is correct', async () => {
     message: customMessage
   }
 
-  let validation = await dependent.validate(createMockContext(['package.json']), settings)
+  let validation = await dependent.processValidate(createMockContext(['package.json']), settings)
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe(customMessage)
 })

--- a/__tests__/unit/validators/description.test.js
+++ b/__tests__/unit/validators/description.test.js
@@ -11,7 +11,7 @@ test('isMergeable is true if the PR body is not empty', async () => {
     }
   }
 
-  let descriptionValidation = await description.validate(createMockPR('This is a mock Description'), settings)
+  let descriptionValidation = await description.processValidate(createMockPR('This is a mock Description'), settings)
   expect(descriptionValidation.status).toBe('pass')
 })
 
@@ -25,10 +25,10 @@ test('isMergeable is false if the PR body is empty', async () => {
     }
   }
 
-  let descriptionValidation = await description.validate(createMockPR(''), settings)
+  let descriptionValidation = await description.processValidate(createMockPR(''), settings)
   expect(descriptionValidation.status).toBe('fail')
 
-  descriptionValidation = await description.validate(createMockPR('Some Description'), settings)
+  descriptionValidation = await description.processValidate(createMockPR('Some Description'), settings)
   expect(descriptionValidation.status).toBe('pass')
 })
 
@@ -42,12 +42,12 @@ test('description is correct', async () => {
     }
   }
 
-  let descriptionValidation = await description.validate(createMockPR(''), settings)
+  let descriptionValidation = await description.processValidate(createMockPR(''), settings)
 
   expect(descriptionValidation.status).toBe('fail')
   expect(descriptionValidation.validations[0].description).toBe("The description can't be empty")
 
-  descriptionValidation = await description.validate(createMockPR('Non empty Description'), settings)
+  descriptionValidation = await description.processValidate(createMockPR('Non empty Description'), settings)
   expect(descriptionValidation.validations[0].description).toBe('The description is not empty')
 })
 
@@ -61,10 +61,10 @@ test('must_include works', async () => {
     }
   }
 
-  let descriptionValidation = await description.validate(createMockPR('test string included'), settings)
+  let descriptionValidation = await description.processValidate(createMockPR('test string included'), settings)
   expect(descriptionValidation.status).toBe('pass')
 
-  descriptionValidation = await description.validate(createMockPR('Non empty Description'), settings)
+  descriptionValidation = await description.processValidate(createMockPR('Non empty Description'), settings)
   expect(descriptionValidation.status).toBe('fail')
   expect(descriptionValidation.validations[0].description).toBe('failed test')
 })
@@ -79,11 +79,11 @@ test('must_exclude works', async () => {
     }
   }
 
-  let descriptionValidation = await description.validate(createMockPR('test string included'), settings)
+  let descriptionValidation = await description.processValidate(createMockPR('test string included'), settings)
   expect(descriptionValidation.status).toBe('fail')
   expect(descriptionValidation.validations[0].description).toBe('failed test')
 
-  descriptionValidation = await description.validate(createMockPR('Non empty Description'), settings)
+  descriptionValidation = await description.processValidate(createMockPR('Non empty Description'), settings)
   expect(descriptionValidation.status).toBe('pass')
 })
 

--- a/__tests__/unit/validators/label.test.js
+++ b/__tests__/unit/validators/label.test.js
@@ -11,10 +11,10 @@ test('validate returns correctly', async () => {
     }
   }
 
-  let results = await label.validate(createMockContext(['wip']), settings)
+  let results = await label.processValidate(createMockContext(['wip']), settings)
   expect(results.status).toBe('fail')
 
-  results = await label.validate(createMockContext(['a', 'b']), settings)
+  results = await label.processValidate(createMockContext(['a', 'b']), settings)
   expect(results.status).toBe('pass')
 })
 
@@ -28,7 +28,7 @@ test('fail gracefully if invalid regex', async () => {
     }
   }
 
-  let validation = await label.validate(createMockContext('WIP'), settings)
+  let validation = await label.processValidate(createMockContext('WIP'), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -42,10 +42,10 @@ test('mergeable is false if regex found or true if not when there is only one la
     }
   }
 
-  let validation = await label.validate(createMockContext('work in progress'), settings)
+  let validation = await label.processValidate(createMockContext('work in progress'), settings)
   expect(validation.status).toBe('fail')
 
-  validation = await label.validate(createMockContext('Some Label'), settings)
+  validation = await label.processValidate(createMockContext('Some Label'), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -59,10 +59,10 @@ test('mergeable is false if regex found or true if not when there are multiple l
     }
   }
 
-  let validation = await label.validate(createMockContext(['abc', 'experimental', 'xyz']), settings)
+  let validation = await label.processValidate(createMockContext(['abc', 'experimental', 'xyz']), settings)
   expect(validation.status).toBe('fail')
 
-  validation = await label.validate(createMockContext(['Some Label', '123', '456']), settings)
+  validation = await label.processValidate(createMockContext(['Some Label', '123', '456']), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -76,12 +76,12 @@ test('description is correct', async () => {
     }
   }
 
-  let validation = await label.validate(createMockContext('Work in Progress'), settings)
+  let validation = await label.processValidate(createMockContext('Work in Progress'), settings)
 
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe('label does not exclude "Work in Progress"')
 
-  validation = await label.validate(createMockContext('Just Label'), settings)
+  validation = await label.processValidate(createMockContext('Just Label'), settings)
   expect(validation.validations[0].description).toBe("label must exclude 'Work in Progress'")
 })
 
@@ -95,10 +95,10 @@ test('mergeable is true if must_include is one of the label', async () => {
     }
   }
 
-  let validation = await label.validate(createMockContext(['abc', 'experimental', 'xyz']), settings)
+  let validation = await label.processValidate(createMockContext(['abc', 'experimental', 'xyz']), settings)
   expect(validation.status).toBe('pass')
 
-  validation = await label.validate(createMockContext(['Some Label', '123', '456']), settings)
+  validation = await label.processValidate(createMockContext(['Some Label', '123', '456']), settings)
   expect(validation.status).toBe('fail')
 })
 
@@ -112,10 +112,10 @@ test('mergeable is false if must_exclude is one of the label', async () => {
     }
   }
 
-  let validation = await label.validate(createMockContext(['abc', 'experimental', 'xyz']), settings)
+  let validation = await label.processValidate(createMockContext(['abc', 'experimental', 'xyz']), settings)
   expect(validation.status).toBe('fail')
 
-  validation = await label.validate(createMockContext(['Some Label', '123', '456']), settings)
+  validation = await label.processValidate(createMockContext(['Some Label', '123', '456']), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -130,11 +130,11 @@ test('that it validates ends_with correctly', async () => {
     }
   }
 
-  let labelValidation = await label.validate(createMockContext(['Some Label']), settings)
+  let labelValidation = await label.processValidate(createMockContext(['Some Label']), settings)
   expect(labelValidation.status).toBe('fail')
   expect(labelValidation.validations[0].description).toBe(`label must end with "${match}"`)
 
-  labelValidation = await label.validate(createMockContext(['Label test']), settings)
+  labelValidation = await label.processValidate(createMockContext(['Label test']), settings)
   expect(labelValidation.status).toBe('pass')
 })
 
@@ -163,17 +163,17 @@ test('complex Logic test', async () => {
     }]
   }
 
-  let validation = await label.validate(createMockContext(['release note: no', 'experimental', 'xyz']), settings)
+  let validation = await label.processValidate(createMockContext(['release note: no', 'experimental', 'xyz']), settings)
   expect(validation.status).toBe('pass')
 
-  validation = await label.validate(createMockContext(['release note: yes', '123', '456']), settings)
+  validation = await label.processValidate(createMockContext(['release note: yes', '123', '456']), settings)
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe('((Please include a language label)  ***OR***  Please include release note: no)')
 
-  validation = await label.validate(createMockContext(['lang/core', '456']), settings)
+  validation = await label.processValidate(createMockContext(['lang/core', '456']), settings)
   expect(validation.validations[0].description).toBe('((Please include release note: yes)  ***OR***  Please include release note: no)')
 
-  validation = await label.validate(createMockContext(['release note: yes', 'lang/core', '456']), settings)
+  validation = await label.processValidate(createMockContext(['release note: yes', 'lang/core', '456']), settings)
   expect(validation.status).toBe('pass')
 })
 

--- a/__tests__/unit/validators/milestone.test.js
+++ b/__tests__/unit/validators/milestone.test.js
@@ -9,7 +9,7 @@ test('should be false when a different milestone is specified', async () => {
       regex: 'Version 2'
     }
   }
-  let validation = await milestone.validate(createMockContext({title: 'Version 1'}), settings)
+  let validation = await milestone.processValidate(createMockContext({title: 'Version 1'}), settings)
   expect(validation.status).toBe('fail')
 })
 
@@ -21,7 +21,7 @@ test('shoud be false when milestone is set in settings but null in PR', async ()
       regex: 'Version 1'
     }
   }
-  let validation = await milestone.validate(createMockContext(), settings)
+  let validation = await milestone.processValidate(createMockContext(), settings)
   expect(validation.status).toBe('fail')
 })
 
@@ -34,7 +34,7 @@ test('description should be correct', async () => {
     }
   }
 
-  let validation = await milestone.validate(createMockContext(), settings)
+  let validation = await milestone.processValidate(createMockContext(), settings)
   expect(validation.validations[0].description).toBe(`milestone does not include "Version 1"`)
 })
 
@@ -47,7 +47,7 @@ test('checks that deep validation works if it closes an issue with milestone req
     }
   }
 
-  let validation = await milestone.validate(createMockContext(null, 'closes #1', {milestone: {title: 'Version 1'}}), settings)
+  let validation = await milestone.processValidate(createMockContext(null, 'closes #1', {milestone: {title: 'Version 1'}}), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -59,7 +59,7 @@ test('checks that deep validation return false if it does not closes an issue wi
       regex: 'Version 1'
     }
   }
-  let validation = await milestone.validate(createMockContext(null, 'closes #1', {milestone: {title: 'Version 2'}}), settings)
+  let validation = await milestone.processValidate(createMockContext(null, 'closes #1', {milestone: {title: 'Version 2'}}), settings)
   expect(validation.status).toBe('fail')
 })
 

--- a/__tests__/unit/validators/or.test.js
+++ b/__tests__/unit/validators/or.test.js
@@ -21,7 +21,7 @@ describe('Or Validator Unit Test', () => {
         }
       ]
     }
-    let validation = await or.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('fail')
   })
 
@@ -44,7 +44,7 @@ describe('Or Validator Unit Test', () => {
         }
       ]
     }
-    let validation = await or.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('pass')
   })
 
@@ -67,7 +67,7 @@ describe('Or Validator Unit Test', () => {
         }
       ]
     }
-    let validation = await or.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('pass')
   })
 
@@ -76,7 +76,7 @@ describe('Or Validator Unit Test', () => {
     const settings = {
       do: 'or'
     }
-    let validation = await or.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 
@@ -86,7 +86,7 @@ describe('Or Validator Unit Test', () => {
       do: 'or',
       validate: ''
     }
-    let validation = await or.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 
@@ -96,7 +96,7 @@ describe('Or Validator Unit Test', () => {
       do: 'or',
       validate: []
     }
-    let validation = await or.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 
@@ -108,7 +108,7 @@ describe('Or Validator Unit Test', () => {
         { do: 'missing' }
       ]
     }
-    let validation = await or.validate(createMockContext({title: 'Version 1'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 1'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 
@@ -143,7 +143,7 @@ describe('Or Validator Unit Test', () => {
       ]
     }
 
-    let validation = await or.validate(createMockContext({title: 'Version 2'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 2'}), settings, registry)
     expect(validation.status).toBe('pass')
   })
 
@@ -178,7 +178,7 @@ describe('Or Validator Unit Test', () => {
       ]
     }
 
-    let validation = await or.validate(createMockContext({title: 'Version 2'}), settings, registry)
+    let validation = await or.processValidate(createMockContext({title: 'Version 2'}), settings, registry)
     expect(validation.status).toBe('error')
   })
 })

--- a/__tests__/unit/validators/project.test.js
+++ b/__tests__/unit/validators/project.test.js
@@ -10,26 +10,26 @@ const settings = {
 
 test('that mergeable is true when PR number is in Project', async () => {
   const projects = new Project()
-  let validation = await projects.validate(createMockContext({number: 1}), settings)
+  let validation = await projects.processValidate(createMockContext({number: 1}), settings)
   expect(validation.status).toBe('pass')
 })
 
 test('that mergeable is false when PR number is not in Project', async () => {
   const projects = new Project()
-  let validation = await projects.validate(createMockContext({number: 3}), settings)
+  let validation = await projects.processValidate(createMockContext({number: 3}), settings)
   expect(validation.status).toBe('fail')
 })
 
 test('test description is correct', async () => {
   const projects = new Project()
-  let validation = await projects.validate(createMockContext({number: 3}), settings)
+  let validation = await projects.processValidate(createMockContext({number: 3}), settings)
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe('Must be in the "Project One" project.')
 })
 
 test('test deep validation works', async () => {
   const projects = new Project()
-  let validation = await projects.validate(createMockContext({number: 3, description: 'closes #1'}), settings)
+  let validation = await projects.processValidate(createMockContext({number: 3, description: 'closes #1'}), settings)
   expect(validation.status).toBe('pass')
   expect(validation.validations[0].description).toBe('Required Project is present')
 })

--- a/__tests__/unit/validators/size.test.js
+++ b/__tests__/unit/validators/size.test.js
@@ -42,7 +42,7 @@ describe('PR size validator', () => {
       }
     }
 
-    let validation = await size.validate(createMockContext(FILES), settings)
+    let validation = await size.processValidate(createMockContext(FILES), settings)
     expect(validation.status).toBe('error')
     expect(validation.validations[0].description).toBe('Options max and total cannot be used together. Please choose one')
     expect(validation.validations[0].status).toBe('error')
@@ -60,7 +60,7 @@ describe('PR size validator', () => {
       }
     }
 
-    let validation = await size.validate(createMockContext(FILES), settings)
+    let validation = await size.processValidate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('Too big!')
     expect(validation.validations[0].status).toBe('fail')
@@ -69,16 +69,10 @@ describe('PR size validator', () => {
   test('errors if invalid configurations is passed', async () => {
     const size = new Size()
     const settings = {
-      do: 'size',
-      lines: {
-        something: {
-          count: 10,
-          message: 'Too big!'
-        }
-      }
+      do: 'size'
     }
 
-    let validation = await size.validate(createMockContext(FILES), settings)
+    let validation = await size.processValidate(createMockContext(FILES), settings)
     const ERROR_MESSAGE = `Failed to validate because the 'lines' or 'max / total', 'additions' or 'deletions' option is missing. Please check the documentation.`
     expect(validation.status).toBe('error')
     expect(validation.validations[0].description).toBe(ERROR_MESSAGE)
@@ -105,7 +99,7 @@ describe('PR size validator', () => {
       }
     }
 
-    let validation = await size.validate(createMockContext(FILES), settings)
+    let validation = await size.processValidate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('Too big!')
     expect(validation.validations[0].status).toBe('fail')
@@ -135,7 +129,7 @@ describe('PR size validator', () => {
       }
     }
 
-    let validation = await size.validate(createMockContext(FILES), settings)
+    let validation = await size.processValidate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
     expect(validation.validations[0].status).toBe('pass')
@@ -165,7 +159,7 @@ describe('PR size validator', () => {
       }
     }
 
-    let validation = await size.validate(createMockContext(FILES), settings)
+    let validation = await size.processValidate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
     expect(validation.validations[0].status).toBe('pass')
@@ -196,7 +190,7 @@ describe('PR size validator', () => {
       ignore: ['another.js']
     }
 
-    let validation = await size.validate(createMockContext(FILES), settings)
+    let validation = await size.processValidate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
     expect(validation.validations[0].status).toBe('pass')
@@ -258,7 +252,7 @@ describe('PR size validator', () => {
       }
     ]
 
-    let validation = await size.validate(createMockContext(files), settings)
+    let validation = await size.processValidate(createMockContext(files), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
     expect(validation.validations[0].status).toBe('pass')
@@ -269,7 +263,7 @@ describe('PR size validator', () => {
 
     settings.ignore = ['**/big_file_*.js']
 
-    validation = await size.validate(createMockContext(files), settings)
+    validation = await size.processValidate(createMockContext(files), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
     expect(validation.validations[0].status).toBe('pass')
@@ -300,7 +294,7 @@ describe('PR size validator', () => {
       ignore: []
     }
 
-    let validation = await size.validate(createMockContext(FILES), settings)
+    let validation = await size.processValidate(createMockContext(FILES), settings)
     expect(validation.status).toBe('fail')
     expect(validation.validations[0].description).toBe('Too big!')
     expect(validation.validations[0].status).toBe('fail')
@@ -328,7 +322,7 @@ describe('PR size validator', () => {
       ignore: []
     }
 
-    validation = await size.validate(createMockContext(FILES), settings)
+    validation = await size.processValidate(createMockContext(FILES), settings)
     expect(validation.status).toBe('pass')
     expect(validation.validations[0].description).toBe('PR size for additions is OK!')
     expect(validation.validations[0].status).toBe('pass')

--- a/__tests__/unit/validators/stale.test.js
+++ b/__tests__/unit/validators/stale.test.js
@@ -27,7 +27,7 @@ test('will set the issues and pulls appropriately when both types are specified'
     { number: 2, pull_request: {} }
   ])
 
-  let results = await stale.validate(context, settings)
+  let results = await stale.processValidate(context, settings)
   expect(isParamsNoType(context)).toBe(true) // it includes both types.
   expect(results.schedule.issues.length).toBe(1)
   expect(results.schedule.pulls.length).toBe(1)
@@ -43,7 +43,7 @@ test('will set the issues and pulls appropriately when no type is set', async ()
     { number: 2, pull_request: {} }
   ])
 
-  let results = await stale.validate(context, settings)
+  let results = await stale.processValidate(context, settings)
   // no types specified so we assume both types. Hence none passed to search API.
   expect(isParamsNoType(context)).toBe(true)
   expect(results.schedule.issues.length).toBe(1)
@@ -60,13 +60,13 @@ test('will set the issues and pulls even when unsupported type is set', async ()
     { number: 2, pull_request: {} }
   ])
 
-  let results = await stale.validate(context, settings)
+  let results = await stale.processValidate(context, settings)
   expect(isParamsNoType(context)).toBe(true) // if non supported is specified we still don't specify.
   expect(results.schedule.issues).toBeDefined()
   expect(results.schedule.pulls).toBeDefined()
 
   settings.type = ['junk', 'issues']
-  results = await stale.validate(context, settings)
+  results = await stale.processValidate(context, settings)
   expect(getFilteredParams(context, 'type:issue').length).toBe(1) // should have called with type:issue
   expect(results.schedule.issues).toBeDefined()
   expect(results.schedule.pulls).toBeDefined()
@@ -76,7 +76,7 @@ test('will set the issues and pulls correctly when type is issue only', async ()
   let settings = {
     do: 'stale',
     days: 10,
-    type: 'issues'
+    type: ['issues']
   }
 
   let stale = new Stale()
@@ -91,7 +91,7 @@ test('will set the issues and pulls correctly when type is issue only', async ()
 
   // no issues came back.
   context = createMockContext([])
-  res = await stale.validate(context, settings)
+  res = await stale.processValidate(context, settings)
   expect(res.status).toBe('fail')
 })
 
@@ -99,13 +99,13 @@ test('will set the issues and pulls correctly when type is pull_request only', a
   let settings = {
     do: 'stale',
     days: 10,
-    type: 'pull_request'
+    type: ['pull_request']
   }
 
   let stale = new Stale()
   let context = createMockContext([{ number: 1, pull_request: {} }])
 
-  let res = await stale.validate(context, settings)
+  let res = await stale.processValidate(context, settings)
   expect(getFilteredParams(context, 'type:issue').length).toBe(0)
   expect(getFilteredParams(context, 'type:pr').length).toBe(1)
   expect(res.schedule.pulls.length).toBe(1)
@@ -114,7 +114,7 @@ test('will set the issues and pulls correctly when type is pull_request only', a
 
   // no prs came back
   context = createMockContext([])
-  res = await stale.validate(context, settings)
+  res = await stale.processValidate(context, settings)
   expect(res.status).toBe('fail')
 })
 
@@ -133,7 +133,7 @@ describe('limit option', () => {
     let stale = new Stale()
     let context = createMockContext([])
 
-    await stale.validate(context, settings)
+    await stale.processValidate(context, settings)
     expect(moment().utc().tz.mock.calls.length).toBe(0)
 
     settings = {
@@ -144,7 +144,7 @@ describe('limit option', () => {
       }
     }
 
-    await stale.validate(context, settings)
+    await stale.processValidate(context, settings)
     expect(moment().utc().tz.mock.calls.length).toBe(1)
     expect(moment().utc().tz.mock.calls[0][0]).toBe(timeZone)
   })
@@ -161,7 +161,7 @@ describe('limit option', () => {
     let stale = new Stale()
     let context = createMockContext([{ number: 1, pull_request: {} }])
 
-    let res = await stale.validate(context, settings)
+    let res = await stale.processValidate(context, settings)
     expect(res.status).toBe('fail')
 
     settings = {
@@ -172,7 +172,7 @@ describe('limit option', () => {
       }
     }
 
-    res = await stale.validate(context, settings)
+    res = await stale.processValidate(context, settings)
     expect(res.status).toBe('pass')
   })
 
@@ -188,7 +188,7 @@ describe('limit option', () => {
     let stale = new Stale()
     let context = createMockContext([{ number: 1, pull_request: {} }])
 
-    let res = await stale.validate(context, settings)
+    let res = await stale.processValidate(context, settings)
     expect(res.status).toBe('pass')
 
     settings = {
@@ -199,7 +199,7 @@ describe('limit option', () => {
       }
     }
 
-    res = await stale.validate(context, settings)
+    res = await stale.processValidate(context, settings)
     expect(res.status).toBe('fail')
 
     settings = {
@@ -210,7 +210,7 @@ describe('limit option', () => {
       }
     }
 
-    res = await stale.validate(context, settings)
+    res = await stale.processValidate(context, settings)
     expect(res.status).toBe('fail')
   })
 })

--- a/__tests__/unit/validators/title.test.js
+++ b/__tests__/unit/validators/title.test.js
@@ -13,10 +13,10 @@ test('validate returns false', async () => {
       regex: 'wip'
     }
   }
-  let result = await title.validate(mockContext('wip'), settings)
+  let result = await title.processValidate(mockContext('wip'), settings)
   expect(result.status).toBe('fail')
 
-  result = await title.validate(mockContext('(feat) something else'), settings)
+  result = await title.processValidate(mockContext('(feat) something else'), settings)
   expect(result.status).toBe('pass')
 })
 
@@ -30,7 +30,7 @@ test('fail gracefully if invalid regex', async () => {
     }
   }
 
-  let titleValidation = await title.validate(mockContext('WIP Title'), settings)
+  let titleValidation = await title.processValidate(mockContext('WIP Title'), settings)
   expect(titleValidation.status).toBe('pass')
 })
 
@@ -47,10 +47,10 @@ test('checks that it fail when exclude regex is in title', async () => {
     }
   }
 
-  let titleValidation = await title.validate(mockContext('WIP Title'), settings)
+  let titleValidation = await title.processValidate(mockContext('WIP Title'), settings)
   expect(titleValidation.status).toBe('fail')
 
-  titleValidation = await title.validate(mockContext('(feat) WIP Title'), settings)
+  titleValidation = await title.processValidate(mockContext('(feat) WIP Title'), settings)
   expect(titleValidation.status).toBe('fail')
 })
 
@@ -71,11 +71,11 @@ test('checks that advance setting of must_include works', async () => {
     }
   }
 
-  let titleValidation = await title.validate(mockContext('include Title'), settings)
+  let titleValidation = await title.processValidate(mockContext('include Title'), settings)
   expect(titleValidation.status).toBe('fail')
   expect(titleValidation.validations[0].description).toBe(testMessage)
 
-  titleValidation = await title.validate(mockContext('(feat) WIP Title'), settings)
+  titleValidation = await title.processValidate(mockContext('(feat) WIP Title'), settings)
 
   expect(titleValidation.status).toBe('fail')
 })
@@ -94,11 +94,11 @@ describe('begins_with', () => {
     let title = new Title()
     let match = '(test)'
 
-    let titleValidation = await title.validate(mockContext('include Title'), mockMatch(match))
+    let titleValidation = await title.processValidate(mockContext('include Title'), mockMatch(match))
     expect(titleValidation.status).toBe('fail')
     expect(titleValidation.validations[0].description).toBe(`title must begins with "${match}"`)
 
-    titleValidation = await title.validate(mockContext('(test) WIP Title'), mockMatch(match))
+    titleValidation = await title.processValidate(mockContext('(test) WIP Title'), mockMatch(match))
     expect(titleValidation.status).toBe('pass')
   })
 
@@ -106,13 +106,13 @@ describe('begins_with', () => {
     let title = new Title()
     let match = ['test1', 'test2']
 
-    let titleValidation = await title.validate(mockContext('include Title'), mockMatch(match))
+    let titleValidation = await title.processValidate(mockContext('include Title'), mockMatch(match))
     expect(titleValidation.status).toBe('fail')
     expect(titleValidation.validations[0].description).toBe(`title must begins with "${match}"`)
 
-    titleValidation = await title.validate(mockContext('test1 WIP Title'), mockMatch(match))
+    titleValidation = await title.processValidate(mockContext('test1 WIP Title'), mockMatch(match))
     expect(titleValidation.status).toBe('pass')
-    titleValidation = await title.validate(mockContext('test2 WIP Title'), mockMatch(match))
+    titleValidation = await title.processValidate(mockContext('test2 WIP Title'), mockMatch(match))
     expect(titleValidation.status).toBe('pass')
   })
 })
@@ -131,11 +131,11 @@ describe('ends_with', () => {
     let title = new Title()
     let match = '(test)'
 
-    let titleValidation = await title.validate(mockContext('include Title'), mockMatch(match))
+    let titleValidation = await title.processValidate(mockContext('include Title'), mockMatch(match))
     expect(titleValidation.status).toBe('fail')
     expect(titleValidation.validations[0].description).toBe(`title must end with "${match}"`)
 
-    titleValidation = await title.validate(mockContext('WIP Title (test)'), mockMatch(match))
+    titleValidation = await title.processValidate(mockContext('WIP Title (test)'), mockMatch(match))
     expect(titleValidation.status).toBe('pass')
   })
 
@@ -143,13 +143,13 @@ describe('ends_with', () => {
     let title = new Title()
     let match = ['test', 'test2']
 
-    let titleValidation = await title.validate(mockContext('include Title'), mockMatch(match))
+    let titleValidation = await title.processValidate(mockContext('include Title'), mockMatch(match))
     expect(titleValidation.status).toBe('fail')
     expect(titleValidation.validations[0].description).toBe(`title must end with "${match}"`)
 
-    titleValidation = await title.validate(mockContext('WIP Title test'), mockMatch(match))
+    titleValidation = await title.processValidate(mockContext('WIP Title test'), mockMatch(match))
     expect(titleValidation.status).toBe('pass')
-    titleValidation = await title.validate(mockContext('WIP Title test2'), mockMatch(match))
+    titleValidation = await title.processValidate(mockContext('WIP Title test2'), mockMatch(match))
     expect(titleValidation.status).toBe('pass')
   })
 })
@@ -168,11 +168,11 @@ test('checks that it fail when include regex is in title', async () => {
     }
   }
 
-  let titleValidation = await title.validate(mockContext('include Title'), settings)
+  let titleValidation = await title.processValidate(mockContext('include Title'), settings)
   expect(titleValidation.status).toBe('fail')
   expect(titleValidation.validations[0].description).toBe(`title does not include "${includeList}"`)
 
-  titleValidation = await title.validate(mockContext('(feat) WIP Title'), settings)
+  titleValidation = await title.processValidate(mockContext('(feat) WIP Title'), settings)
 
   expect(titleValidation.status).toBe('fail')
 })

--- a/docs/validators/approval.rst
+++ b/docs/validators/approval.rst
@@ -11,7 +11,7 @@ Approvals
         reviewers: [ user1, user2 ] # list of github usernames required to review
         owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and owners made required reviewers
         assignees: true # Optional boolean. When true, PR assignees are made required reviewers.
-        pending_reviewer: true # Optional boolean. When true, all the requested reviewer's approval is required
+        requested_reviewers: true # Optional boolean. When true, all the requested reviewer's approval is required
         message: 'Custom message...'
       block:
         changes_requested: true # If true, block all approvals when one of the reviewers gave 'changes_requested' review

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -32,11 +32,16 @@ class Approvals extends Validator {
         count: 'number',
         message: 'string'
       },
+      max: {
+        count: 'number',
+        message: 'string'
+      },
       required: {
         reviewers: 'array',
         owners: 'boolean',
         assignees: 'boolean',
         pending_reviewer: 'boolean',
+        requested_reviewers: 'boolean',
         message: 'string'
       },
       block: {

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -40,7 +40,6 @@ class Approvals extends Validator {
         reviewers: 'array',
         owners: 'boolean',
         assignees: 'boolean',
-        pending_reviewer: 'boolean',
         requested_reviewers: 'boolean',
         message: 'string'
       },

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -27,7 +27,7 @@ class Dependent extends Validator {
       message: 'string',
       changed: {
         file: 'string',
-        required: 'string',
+        required: 'array',
         files: 'array'
       }
     }


### PR DESCRIPTION
Context
fix the tests to make sure the `validateSetting` is called to make sure all the valid settings implemented are a part of `supportedSettings`

this PR includes fixes to the `supportedSettings` that were missing, which is currently breaking production for certain settings