### PR TITLE
feat: display error comment if error occured during action execution

### DIFF
--- a/__fixtures__/e2e/helper.js
+++ b/__fixtures__/e2e/helper.js
@@ -5,6 +5,7 @@ const checkUpdateResponse = require('./check.update.response.json')
 const checkCreateResponse = require('./check.create.response.json')
 const configResponse = require('./config.response.json')
 const prListFilesResponse = require('./pr.listFile.response.json')
+const issueCommentResponse = require('./issue.listComment.response.json')
 const defaultConfig = fs.readFileSync('./__fixtures__/e2e/config.v1.default.yml', 'utf8')
 
 class MockHelper {
@@ -50,6 +51,14 @@ class MockHelper {
   mockPRListFileCall (options = {}) {
     const response = options.response ? options.response : prListFilesResponse
     const path = `/repos/${this.repo.owner.login}/${this.repo.name}/pulls/${this.payload.number}/files`
+    return nock('https://api.github.com')
+      .get(path)
+      .reply(200, response)
+  }
+
+  mockIssueListCommentsCall (options = {}) {
+    const response = options.response ? options.response : issueCommentResponse
+    const path = `/repos/${this.repo.owner.login}/${this.repo.name}/issues/${this.payload.number}/comments`
     return nock('https://api.github.com')
       .get(path)
       .reply(200, response)

--- a/__fixtures__/e2e/issue.listComment.response.json
+++ b/__fixtures__/e2e/issue.listComment.response.json
@@ -1,0 +1,8 @@
+[
+  {
+    "user": {
+      "login": "Mergeable[bot]"
+    },
+    "body": "Comment by Mergeable"
+  }
+]

--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -37,6 +37,12 @@ module.exports = {
               issues_url: 'testRepo/issues{/number}'
             }},
           assignees: (options.assignees) ? options.assignees : []
+        },
+        issue: {
+          user: {
+            login: 'creator'
+          },
+          number: (options.number) ? options.number : 1
         }
       },
       log: {

--- a/__tests__/e2e/smoke.test.js
+++ b/__tests__/e2e/smoke.test.js
@@ -65,6 +65,7 @@ mergeable:
     const updateCheckCall = Helper.mockCheckUpdateCall(updateCheckOptions)
     const createCheckCall = Helper.mockCheckCreateCall(createCheckOptions)
     const listFilesCall = Helper.mockPRListFileCall()
+    const listCommentsCall = Helper.mockIssueListCommentsCall()
     const fetchConfigCall = Helper.mockFetchConfigCall({config})
 
     // Receive a webhook event
@@ -74,6 +75,7 @@ mergeable:
     expect(updateCheckCall.isDone()).toBe(true)
     expect(createCheckCall.isDone()).toBe(true)
     expect(listFilesCall.isDone()).toBe(true)
+    expect(listCommentsCall.isDone()).toBe(true)
     expect(fetchConfigCall.isDone()).toBe(true)
 
     // check that api calls were made with expect request body

--- a/__tests__/unit/actions/comment.test.js
+++ b/__tests__/unit/actions/comment.test.js
@@ -76,6 +76,70 @@ test('check that old comments from Mergeable are deleted if they exists', async 
   expect(context.github.issues.deleteComment.mock.calls[0][0].comment_id).toBe(`2`)
 })
 
+test('error handling includes removing old error comments and creating new error comment', async () => {
+  const comment = new Comment()
+
+  const listComments = [{
+    id: '1',
+    user: {
+      login: 'test-1'
+    }
+  },
+  {
+    id: '2',
+    user: {
+      login: 'Mergeable[bot]'
+    },
+    body: 'This is a normal comment'
+  },
+  {
+    id: '3',
+    user: {
+      login: 'Mergeable[bot]'
+    },
+    body: 'This is an Error comment'
+  }]
+  const context = createMockContext(listComments)
+  const payload = {
+    body: 'This is a new error comment'
+  }
+
+  await comment.handleError(context, payload)
+  expect(context.github.issues.deleteComment.mock.calls.length).toBe(1)
+  expect(context.github.issues.deleteComment.mock.calls[0][0].comment_id).toBe(`3`)
+  expect(context.github.issues.createComment.mock.calls[0][0].body).toBe(payload)
+})
+
+test('remove error comments only remove comments that includes "error" ', async () => {
+  const comment = new Comment()
+
+  const listComments = [{
+    id: '1',
+    user: {
+      login: 'test-1'
+    }
+  },
+  {
+    id: '2',
+    user: {
+      login: 'Mergeable[bot]'
+    },
+    body: 'This is a normal comment'
+  },
+  {
+    id: '3',
+    user: {
+      login: 'Mergeable[bot]'
+    },
+    body: 'This is an Error comment'
+  }]
+  const context = createMockContext(listComments)
+
+  await comment.removeErrorComments(context)
+  expect(context.github.issues.deleteComment.mock.calls.length).toBe(1)
+  expect(context.github.issues.deleteComment.mock.calls[0][0].comment_id).toBe(`3`)
+})
+
 test('check that leave_old_comment option works', async () => {
   const comment = new Comment()
 

--- a/__tests__/unit/actions/comment.test.js
+++ b/__tests__/unit/actions/comment.test.js
@@ -107,7 +107,7 @@ test('error handling includes removing old error comments and creating new error
   await comment.handleError(context, payload)
   expect(context.github.issues.deleteComment.mock.calls.length).toBe(1)
   expect(context.github.issues.deleteComment.mock.calls[0][0].comment_id).toBe(`3`)
-  expect(context.github.issues.createComment.mock.calls[0][0].body).toBe(payload)
+  expect(context.github.issues.createComment.mock.calls[0][0].body).toBe(payload.body)
 })
 
 test('remove error comments only remove comments that includes "error" ', async () => {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| June 16, 2020 : Create an error comment if errors have occurred during execution of actions `#312 <https://github.com/mergeability/mergeable/issues/312>`_
 | June 5, 2020 : For missing fields in 'checks', default values will be used `#233 <https://github.com/mergeability/mergeable/issues/233#issuecomment-632211789>`_
 | May 30, 2020 : New Action `merge` added `#201 <https://github.com/mergeability/mergeable/issues/228>`_
 | May 29, 2020 : throw `UnSupportedSettingError` if provided setting is not valid `#228 <https://github.com/mergeability/mergeable/issues/228>`_

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -13,13 +13,10 @@ const fetchCommentsByMergeable = async (context, issueNumber) => {
   )
 
   const botName = process.env.APP_NAME ? process.env.APP_NAME : 'Mergeable'
-
   return comments.data.filter(comment => comment.user.login === `${botName}[bot]`)
 }
 
-const deleteOldComments = async (context, issueNumber) => {
-  const oldComments = await fetchCommentsByMergeable(context, issueNumber)
-
+const deleteOldComments = async (context, oldComments) => {
   for (let comment of oldComments) {
     await context.github.issues.deleteComment(
       context.repo({ comment_id: comment.id })
@@ -37,12 +34,33 @@ class Comment extends Action {
     ]
   }
 
+  async handleError (context, payload) {
+    const issueNumber = this.getPayload(context).number
+
+    await this.removeErrorComments(context)
+
+    return createComment(
+      context,
+      issueNumber,
+      payload.body
+    )
+  }
+
+  async removeErrorComments (context) {
+    const issueNumber = this.getPayload(context).number
+    const oldComments = await fetchCommentsByMergeable(context, issueNumber)
+    const errorComments = oldComments.filter(comment => comment.body.toLowerCase().includes('error'))
+
+    return deleteOldComments(context, errorComments)
+  }
+
   // there is nothing to do
   async beforeValidate () {}
 
   async afterValidate (context, settings, name, results) {
     if (!settings.leave_old_comment) {
-      await deleteOldComments(context, this.getPayload(context).number)
+      const oldComments = await fetchCommentsByMergeable(context, this.getPayload(context).number)
+      await deleteOldComments(context, oldComments)
     }
 
     let scheduleResults = results.validationSuites && results.validationSuites[0].schedule

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -1,6 +1,7 @@
 const Configuration = require('./configuration/configuration')
 const extractValidationStats = require('./stats/extractValidationStats')
 const Checks = require('./actions/checks')
+const Comment = require('./actions/comment')
 const Register = require('./register')
 const interceptors = require('./interceptors')
 const consolidateResult = require('./validators/options_processor/options/lib/consolidateResults')
@@ -152,7 +153,21 @@ const processWorkflow = async (context, registry, config) => {
       const translatedOutput = extractValidationStats(result)
       const promises = getActionPromises(context, registry, rule, translatedOutput)
       if (promises) {
+        let errorOccurred = false
+
+        const event = `${context.event}.${context.payload.action}`
+        const comment = new Comment()
+
         await Promise.all(promises).catch((err) => {
+          errorOccurred = true
+          const payload = {
+            body: '####  :x: Error Occurred while executing an Action \n\n ' +
+            'If you believe this is an unexpected error, please report it on our issue tracker: https://github.com/mergeability/mergeable/issues/new \n' +
+            '##### Error Details \n' +
+            '-------------------- \n' +
+            `${err.toString()}`
+          }
+
           const unknownErrorLog = {
             log_type: logger.logTypes.UNKNOWN_ERROR_ACTION,
             errors: err.toString(),
@@ -161,7 +176,12 @@ const processWorkflow = async (context, registry, config) => {
             settings: JSON.stringify(config.settings)
           }
           log.error(unknownErrorLog)
+          if (comment.isEventSupported(event)) {
+            comment.handleError(context, payload)
+          }
         })
+
+        if (!errorOccurred && comment.isEventSupported(event)) await comment.removeErrorComments(context)
       }
     }
   }


### PR DESCRIPTION
If there is an error during `action` execution, a error comment will be created.
Every time a new error comment is created, old error comments will be deleted
During the next mergeable run, if none of the action throws error, the error comment will be deleted


![image](https://user-images.githubusercontent.com/5243508/84847145-40ff0000-b005-11ea-84d3-353f9e2de299.png)

closes #312 