### PR TITLE
feat: contents validator

### DIFF
--- a/__tests__/unit/validators/contents.test.js
+++ b/__tests__/unit/validators/contents.test.js
@@ -1,7 +1,7 @@
 const Helper = require('../../../__fixtures__/unit/helper')
 const Contents = require('../../../lib/validators/contents')
 
-test.only('files pr_diff option works correctly', async () => {
+test('files pr_diff option works correctly', async () => {
   const contents = new Contents()
   const settings = {
     do: 'contents',
@@ -21,7 +21,7 @@ test.only('files pr_diff option works correctly', async () => {
   expect(validation.status).toBe('pass')
 })
 
-test.only('files ignore option works correctly', async () => {
+test('files ignore option works correctly', async () => {
   const contents = new Contents()
   let settings = {
     do: 'contents',

--- a/__tests__/unit/validators/contents.test.js
+++ b/__tests__/unit/validators/contents.test.js
@@ -41,14 +41,14 @@ test.only('files ignore option works correctly', async () => {
     do: 'contents',
     files: {
       pr_diff: true,
-      ignore: []
+      ignore: ['package.json']
     },
     must_exclude: {
       regex: 'test'
     }
   }
 
-  validation = await contents.processValidate(createMockContext(['.github/mergeable.yml', 'package.json'], 'string'), settings)
+  validation = await contents.processValidate(createMockContext(['package.json'], 'string'), settings)
   expect(validation.status).toBe('pass')
 })
 

--- a/__tests__/unit/validators/contents.test.js
+++ b/__tests__/unit/validators/contents.test.js
@@ -1,0 +1,65 @@
+const Helper = require('../../../__fixtures__/unit/helper')
+const Contents = require('../../../lib/validators/contents')
+
+test.only('files pr_diff option works correctly', async () => {
+  const contents = new Contents()
+  const settings = {
+    do: 'contents',
+    files: {
+      pr_diff: true
+    },
+    must_exclude: {
+      regex: 'test'
+    }
+  }
+
+  let validation = await contents.processValidate(createMockContext(['package.json'], 'testString'), settings)
+  expect(validation.status).toBe('fail')
+  expect(validation.validations[0].description.includes('package.json')).toBe(true)
+
+  validation = await contents.processValidate(createMockContext(['package.json'], 'string'), settings)
+  expect(validation.status).toBe('pass')
+})
+
+test.only('files ignore option works correctly', async () => {
+  const contents = new Contents()
+  let settings = {
+    do: 'contents',
+    files: {
+      pr_diff: true
+    },
+    must_exclude: {
+      regex: 'test'
+    }
+  }
+
+  let validation = await contents.processValidate(createMockContext(['.github/mergeable.yml', 'package.json'], 'testString'), settings)
+  expect(validation.status).toBe('fail')
+  expect(validation.validations[0].description).toBe("Failed files : 'package.json'")
+
+  settings = {
+    do: 'contents',
+    files: {
+      pr_diff: true,
+      ignore: []
+    },
+    must_exclude: {
+      regex: 'test'
+    }
+  }
+
+  validation = await contents.processValidate(createMockContext(['.github/mergeable.yml', 'package.json'], 'string'), settings)
+  expect(validation.status).toBe('pass')
+})
+
+const createMockContext = (files, fileContent) => {
+  const context = Helper.mockContext({files: files})
+
+  context.github.repos.getContents = () => {
+    return Promise.resolve({ data: {
+      content: Buffer.from(fileContent).toString('base64') }
+    })
+  }
+
+  return context
+}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| June 17, 2020 : Added new validator `contents` `#207 <https://github.com/mergeability/mergeable/issues/207>`_
 | June 5, 2020 : For missing fields in 'checks', default values will be used `#233 <https://github.com/mergeability/mergeable/issues/233#issuecomment-632211789>`_
 | May 30, 2020 : New Action `merge` added `#201 <https://github.com/mergeability/mergeable/issues/228>`_
 | May 29, 2020 : throw `UnSupportedSettingError` if provided setting is not valid `#228 <https://github.com/mergeability/mergeable/issues/228>`_

--- a/docs/validators/contents.rst
+++ b/docs/validators/contents.rst
@@ -1,0 +1,26 @@
+Contents
+^^^^^^^^^^^^^^
+
+::
+
+    - do: contents
+      files: # determine which files contents to validate
+        pr_diff: true # If true, validator will grab all the added and modified files in the head of the PR
+        ignore: ['.github/mergeable.yml'] # Optional, default ['.github/mergeable.yml'], pattern of files to ignore
+      must_include:
+         regex: 'yarn.lock'
+         message: 'Custom message...'
+      must_exclude:
+         regex: 'package.json'
+         message: 'Custom message...'
+      begins_with:
+         match: 'A String' # or array of strings
+         message: 'Some message...'
+      ends_with:
+         match: 'A String' # or array of strings
+         message: 'Come message...'
+
+Supported Events:
+::
+
+    'pull_request.*', 'pull_request_review.*'

--- a/docs/validators/contents.rst
+++ b/docs/validators/contents.rst
@@ -20,6 +20,9 @@ Contents
          match: 'A String' # or array of strings
          message: 'Come message...'
 
+.. warning::
+    ``merge`` action will not work currently as it require ``contents`` ``read:write`` permission which the mergeable doesn't have. We have plans to enable it in the near future
+
 Supported Events:
 ::
 

--- a/lib/validators/contents.js
+++ b/lib/validators/contents.js
@@ -87,7 +87,6 @@ const getContent = async (context, path) => {
   })).then(res => {
     return Buffer.from(res.data.content, 'base64').toString()
   }).catch(error => {
-    console.log(error)
     if (error.status === 404) return null
     else throw error
   })

--- a/lib/validators/contents.js
+++ b/lib/validators/contents.js
@@ -1,0 +1,91 @@
+const { Validator } = require('./validator')
+const minimatch = require('minimatch')
+const consolidateResult = require('./options_processor/options/lib/consolidateResults')
+const constructOutput = require('./options_processor/options/lib/constructOutput')
+
+const DEFAULT_SUCCESS_MESSAGE = 'Your Contents passes validations'
+const VALIDATOR_CONTEXT = { name: 'contents' }
+
+class Contents extends Validator {
+  constructor () {
+    super('contents')
+    this.supportedEvents = [
+      'pull_request.*',
+      'pull_request_review.*'
+    ]
+    this.supportedSettings = {
+      files: {
+        pr_diff: 'boolean',
+        ignore: 'array'
+      },
+      must_include: {
+        regex: 'string',
+        regex_flag: 'string',
+        message: 'string'
+      },
+      must_exclude: {
+        regex: 'string',
+        regex_flag: 'string',
+        message: 'string'
+      },
+      begins_with: {
+        match: ['string', 'array'],
+        message: 'string'
+      },
+      ends_with: {
+        match: ['string', 'array'],
+        message: 'string'
+      }
+    }
+  }
+
+  async validate (context, validationSettings) {
+    if (validationSettings) {
+      delete validationSettings.files
+    }
+
+    const patternsToIgnore = validationSettings.ignore || ['.github/mergeable.yml']
+
+    let result = await context.github.pulls.listFiles(context.repo({pull_number: this.getPayload(context).number}))
+    let changedFiles = result.data
+      .filter(file => !matchesIgnoredPatterns(file.filename, patternsToIgnore))
+      .filter(file => file.status === 'modified' || file.status === 'added')
+      .map(file => file.filename)
+
+    let failedFiles = []
+    for (let file of changedFiles) {
+      const content = await getContent(context, file)
+
+      const processed = this.processOptions(validationSettings, content)
+      if (processed.status === 'error') return processed
+      if (processed.status === 'fail') failedFiles.push(file)
+    }
+
+    const isMergeable = failedFiles.length === 0
+    const output = [constructOutput(VALIDATOR_CONTEXT, changedFiles, validationSettings, {
+      status: isMergeable ? 'pass' : 'fail',
+      description: isMergeable ? DEFAULT_SUCCESS_MESSAGE : `Failed files : '${failedFiles.join(',')}'`
+    })]
+
+    return consolidateResult(output, VALIDATOR_CONTEXT)
+  }
+}
+
+const matchesIgnoredPatterns = (filename, patternsToIgnore) => (
+  patternsToIgnore.some((ignorePattern) => minimatch(filename, ignorePattern))
+)
+
+const getContent = async (context, path) => {
+  return context.github.repos.getContents(context.repo({
+    path: path,
+    ref: context.payload.pull_request.head.sha
+  })).then(res => {
+    return Buffer.from(res.data.content, 'base64').toString()
+  }).catch(error => {
+    console.log(error)
+    if (error.status === 404) return null
+    else throw error
+  })
+}
+
+module.exports = Contents

--- a/lib/validators/contents.js
+++ b/lib/validators/contents.js
@@ -40,11 +40,16 @@ class Contents extends Validator {
   }
 
   async validate (context, validationSettings) {
-    if (validationSettings) {
-      delete validationSettings.files
-    }
+    let fileOptions = null
+    let patternsToIgnore = ['.github/mergeable.yml']
 
-    const patternsToIgnore = validationSettings.ignore || ['.github/mergeable.yml']
+    let parseOption = validationSettings
+
+    if (validationSettings.files) {
+      fileOptions = validationSettings.files
+      if (fileOptions.ignore) patternsToIgnore = fileOptions.ignore
+      delete parseOption.files
+    }
 
     let result = await context.github.pulls.listFiles(context.repo({pull_number: this.getPayload(context).number}))
     let changedFiles = result.data
@@ -56,7 +61,7 @@ class Contents extends Validator {
     for (let file of changedFiles) {
       const content = await getContent(context, file)
 
-      const processed = this.processOptions(validationSettings, content)
+      const processed = this.processOptions(parseOption, content)
       if (processed.status === 'error') return processed
       if (processed.status === 'fail') failedFiles.push(file)
     }


### PR DESCRIPTION
### Add contents validator
config 
```
    - do: contents
      files: # determine which files contents to validate
        pr_diff: true # If true, validator will grab all the added and modified files in the head of the PR
        ignore: ['.github/mergeable.yml'] # Optional, default ['.github/mergeable.yml'], pattern of files to ignore
      must_include:
         regex: 'yarn.lock'
         message: 'Custom message...'
      must_exclude:
         regex: 'package.json'
         message: 'Custom message...'
      begins_with:
         match: 'A String' # or array of strings
         message: 'Some message...'
      ends_with:
         match: 'A String' # or array of strings
         message: 'Come message...'
```

sample output

![image](https://user-images.githubusercontent.com/5243508/84967941-20e54480-b0ca-11ea-8e20-cefc7b824d9f.png)

closes #207 