### PR TITLE
feat: ignore_comments option for `size` validator

### DIFF
--- a/__tests__/unit/validators/size.test.js
+++ b/__tests__/unit/validators/size.test.js
@@ -1,5 +1,8 @@
+jest.mock('node-fetch')
+
 const Helper = require('../../../__fixtures__/unit/helper')
 const Size = require('../../../lib/validators/size')
+let mockedFetch = require('node-fetch')
 
 describe('PR size validator', () => {
   const FILES = [
@@ -330,6 +333,212 @@ describe('PR size validator', () => {
     expect(validation.validations[1].status).toBe('pass')
     expect(validation.validations[2].description).toBe('PR size for total additions + deletions is OK!')
     expect(validation.validations[2].status).toBe('pass')
+  })
+})
+
+describe('Size Ignore comment functionality', () => {
+  const FILES = [
+    {
+      filename: 'thing.js',
+      status: 'modified',
+      additions: 10,
+      deletions: 5,
+      changes: 15
+    },
+    {
+      filename: 'another.js',
+      status: 'added',
+      additions: 3,
+      deletions: 2,
+      changes: 5
+    },
+    {
+      filename: 'removed_file_should_be_ignored.js',
+      status: 'removed',
+      additions: 0,
+      deletions: 500,
+      changes: 500
+    }
+  ]
+
+  test('both single line comments and block comments are ignored', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        total: {
+          count: 1,
+          message: 'Too big!'
+        },
+        ignore_comments: true
+      }
+    }
+
+    mockedFetch.mockReturnValueOnce({
+      text: () => {
+        return 'diff --git a/commentTestFiles.js b/commentTestFiles.js\n' +
+          'new file mode 100644\n' +
+          'index 0000000..983b141\n' +
+          '--- /dev/null\n' +
+          '+++ b/commentTestFiles.js\n' +
+          '@@ -0,0 +1,5 @@\n' +
+          '+// this is a comment\n' +
+          '+ // second comment\n' +
+          '+ non comment\n' +
+          '+\n' +
+          '+/*\n' +
+          '+    Comment block\n' +
+          '+ */\n'
+      }
+    })
+
+    let validation = await size.processValidate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('fail')
+
+    mockedFetch.mockReturnValueOnce({
+      text: () => {
+        return 'diff --git a/commentTestFiles.js b/commentTestFiles.js\n' +
+          'new file mode 100644\n' +
+          'index 0000000..983b141\n' +
+          '--- /dev/null\n' +
+          '+++ b/commentTestFiles.js\n' +
+          '@@ -0,0 +1,5 @@\n' +
+          '+// this is a comment\n' +
+          '+/*\n' +
+          '+    Comment block\n' +
+          '+ */\n'
+      }
+    })
+
+    validation = await size.processValidate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('pass')
+    expect(validation.validations[0].description).toBe('PR size for total additions + deletions is OK!')
+  })
+
+  test('non supported file extension are ignored', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        total: {
+          count: 1,
+          message: 'Too big!'
+        },
+        ignore_comments: true
+      }
+    }
+
+    mockedFetch.mockReturnValueOnce({
+      text: () => {
+        return 'diff --git a/commentTestFiles.notsupportedExtension b/commentTestFiles.notsupportedExtension\n' +
+          'new file mode 100644\n' +
+          'index 0000000..983b141\n' +
+          '--- /dev/null\n' +
+          '+++ b/commentTestFiles.notsupportedExtension\n' +
+          '@@ -0,0 +1,5 @@\n' +
+          '+// this is a comment\n' +
+          '+/*\n' +
+          '+    Comment block\n' +
+          '+ */\n'
+      }
+    })
+
+    let validation = await size.processValidate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('fail')
+  })
+
+  test('.js file extension works properly', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        total: {
+          count: 1,
+          message: 'Too big!'
+        },
+        ignore_comments: true
+      }
+    }
+
+    mockedFetch.mockReturnValueOnce({
+      text: () => {
+        return 'diff --git a/commentTestFiles.js b/commentTestFiles.js\n' +
+          'new file mode 100644\n' +
+          'index 0000000..983b141\n' +
+          '--- /dev/null\n' +
+          '+++ b/commentTestFiles.js\n' +
+          '@@ -0,0 +1,5 @@\n' +
+          '+// this is a comment\n' +
+          '+ // second comment\n'
+      }
+    })
+
+    let validation = await size.processValidate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('pass')
+
+    mockedFetch.mockReturnValueOnce({
+      text: () => {
+        return 'diff --git a/commentTestFiles.js b/commentTestFiles.js\n' +
+          'new file mode 100644\n' +
+          'index 0000000..983b141\n' +
+          '--- /dev/null\n' +
+          '+++ b/commentTestFiles.js\n' +
+          '@@ -0,0 +1,5 @@\n' +
+          '+/*\n' +
+          '+    Comment block\n' +
+          '+ */\n'
+      }
+    })
+
+    validation = await size.processValidate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('pass')
+  })
+
+  test('.py file extension works properly', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        total: {
+          count: 0,
+          message: 'Too big!'
+        },
+        ignore_comments: true
+      }
+    }
+
+    mockedFetch.mockReturnValueOnce({
+      text: () => {
+        return 'diff --git a/commentTestFiles.py b/commentTestFiles.py\n' +
+          'new file mode 100644\n' +
+          'index 0000000..983b141\n' +
+          '--- /dev/null\n' +
+          '+++ b/commentTestFiles.js\n' +
+          '@@ -0,0 +1,5 @@\n' +
+          '+# this is a comment\n' +
+          '+ # second comment\n' +
+          '+ non comment\n'
+      }
+    })
+
+    let validation = await size.processValidate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('fail')
+
+    mockedFetch.mockReturnValueOnce({
+      text: () => {
+        return 'diff --git a/commentTestFiles.py b/commentTestFiles.py\n' +
+          'new file mode 100644\n' +
+          'index 0000000..983b141\n' +
+          '--- /dev/null\n' +
+          '+++ b/commentTestFiles.py\n' +
+          '@@ -0,0 +1,5 @@\n' +
+          '+# this is a comment\n' +
+          '+ # second comment\n'
+      }
+    })
+
+    validation = await size.processValidate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('pass')
   })
 })
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| June 30, 2020 : Add `ignore_comment` option to `size` validator `#245 <https://github.com/mergeability/mergeable/issues/245>`_
 | June 5, 2020 : For missing fields in 'checks', default values will be used `#233 <https://github.com/mergeability/mergeable/issues/233#issuecomment-632211789>`_
 | May 30, 2020 : New Action `merge` added `#201 <https://github.com/mergeability/mergeable/issues/228>`_
 | May 29, 2020 : throw `UnSupportedSettingError` if provided setting is not valid `#228 <https://github.com/mergeability/mergeable/issues/228>`_

--- a/docs/validators/size.rst
+++ b/docs/validators/size.rst
@@ -2,6 +2,7 @@ Size
 ^^^^^^^^^^
 ``size`` validates that the size of changes in the pull request conform to a specified limit. We can pass in three options: ``total``, ``additions`` or ``deletions``. Each of this take in a count and message.
 Validates that the files specified are all part of a pull request (added or modified).
+
 ::
 
   - do: size
@@ -15,8 +16,13 @@ Validates that the files specified are all part of a pull request (added or modi
       deletions:
         count: 500
         message: Change is very large. Should be under 250 lines of deletions.
+      ignore_comments: false #if true, comments will not be counted toward the lines count
 
 ``max`` is an alias for total, so the below configuration is still valid.
+
+
+.. warning::
+    currently ``ignore_comments`` feat only works with '.js' and '.py' extensions, if you have request for more file extensions please create a ticket `here <https://github.com/mergeability/mergeable/issues/new>`_
 
 ::
 

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -7,9 +7,26 @@ const constructOutput = require('./options_processor/options/lib/constructOutput
 const consolidateResult = require('./options_processor/options/lib/consolidateResults')
 const constructErrorOutput = require('./options_processor/options/lib/constructErrorOutput')
 
+const SINGLE_LINE_COMMENT_REGEXES = {
+  '.js': /^\/\//i,
+  '.py': /^#/i
+}
+
+const BLOCK_COMMENT_REGEXES = {
+  '.js': {
+    beginning: /\/\*/i,
+    end: /\*\//i
+  },
+  '.py': null
+}
+
 class Size extends Validator {
   constructor () {
     super('size')
+    this.supportedFileExtensionForCommentIgnore = [
+      '.js',
+      '.py'
+    ]
     this.supportedEvents = [
       'pull_request.opened',
       'pull_request.edited',
@@ -60,20 +77,23 @@ class Size extends Validator {
       context.repo({pull_number: payload.number})
     )
 
-    await calculateChangesWithoutComments(this.getPayload(context).diff_url)
-
-    // Possible file statuses: addded, modified, removed.
-    const modifiedFiles = listFilesResult.data
-      .filter(file => !matchesIgnoredPatterns(file.filename, patternsToIgnore))
-      .filter(file => file.status === 'modified' || file.status === 'added')
-      .map(
-        file => ({
-          filename: file.filename,
-          additions: file.additions,
-          deletions: file.deletions,
-          changes: file.changes
-        })
-      )
+    let modifiedFiles
+    if (validationSettings.lines && validationSettings.lines.ignore_comments) {
+      modifiedFiles = await this.calculateChangesWithoutComments(this.getPayload(context).diff_url)
+    } else {
+      // Possible file statuses: added, modified, removed.
+      modifiedFiles = listFilesResult.data
+        .filter(file => !matchesIgnoredPatterns(file.filename, patternsToIgnore))
+        .filter(file => file.status === 'modified' || file.status === 'added')
+        .map(
+          file => ({
+            filename: file.filename,
+            additions: file.additions,
+            deletions: file.deletions,
+            changes: file.changes
+          })
+        )
+    }
 
     let prSizeChanges = {
       additions: 0,
@@ -162,53 +182,75 @@ class Size extends Validator {
 
     return consolidateResult(output, validatorContext)
   }
+
+  async calculateChangesWithoutComments (url) {
+    const response = await fetch(url)
+    const diffs = await response.text()
+    const files = diffs.split('diff --git')
+    files.shift()
+
+    const processedFiles = []
+
+    for (let file of files) {
+      const filename = extractFileName(file)
+      const fileExtension = extractFileExtension(filename)
+
+      const lines = file.split('\n')
+
+      if (file.includes('deleted')) continue
+
+      const addOrDeleteRegex = new RegExp(/^(\+|-)/i)
+      const fileModifierRegex = new RegExp(/(\+\+\+|---)/i)
+      const singleLineCommentRegex = new RegExp(SINGLE_LINE_COMMENT_REGEXES[fileExtension])
+
+      let additions = 0
+      let deletions = 0
+      let isBlockCommentActive = false
+      for (let line of lines) {
+        if (addOrDeleteRegex.test(line) && !fileModifierRegex.test(line)) {
+          if (this.supportedFileExtensionForCommentIgnore.includes(fileExtension)) {
+            const lineContent = line.substring(1).trim()
+            if (singleLineCommentRegex.test(lineContent)) continue
+
+            if (BLOCK_COMMENT_REGEXES[fileExtension] !== null) {
+              const blockCommentStartRegex = new RegExp(BLOCK_COMMENT_REGEXES[fileExtension].beginning)
+              const blockCommentEndRegex = new RegExp(BLOCK_COMMENT_REGEXES[fileExtension].end)
+
+              if (isBlockCommentActive) {
+                if (blockCommentEndRegex.test(lineContent)) isBlockCommentActive = false
+                continue
+              } else if (blockCommentStartRegex.test(lineContent)) {
+                if (!blockCommentEndRegex.test(lineContent)) {
+                  isBlockCommentActive = true
+                }
+                continue
+              }
+            }
+          }
+
+          const plusOrMinus = line[0]
+          if (plusOrMinus === '+') additions++
+          else deletions++
+        }
+      }
+
+      processedFiles.push({
+        filename: filename,
+        additions,
+        deletions,
+        changes: additions + deletions
+      })
+    }
+
+    return processedFiles
+  }
 }
 
-const calculateChangesWithoutComments = async (url) => {
-  const response = await fetch(url)
-  const diffs = await response.text()
+const extractFileExtension = (filename) => {
+  const fileExtensionRegex = new RegExp(/\.[0-9a-z]+$/i)
 
-  const files = diffs.split('diff --git')
-  files.shift()
-
-  const processedFiles = []
-
-  for (let file of files) {
-    const lines = file.split('\n')
-
-    if (file.includes('deleted')) continue
-
-    let fileStatus = 'modified'
-    if (file.includes('--- /dev/null')) {
-      fileStatus = 'added'
-    }
-    const addOrDeleteRegex = new RegExp(/^(\+|-)/i)
-    const fileModifierRegex = new RegExp(/(\+\+\+|---)/i)
-
-    let additions = 0
-    let deletions = 0
-    for (let line of lines) {
-      if (addOrDeleteRegex.test(line) && !fileModifierRegex.test(line)) {
-        const lineContent = line.substring(1).trim()
-
-        const plusOrMinus = line[0]
-        if (plusOrMinus === '+') additions++
-        else deletions++
-
-        console.log(lineContent)
-      }
-    }
-
-    processedFiles.push({
-      status: fileStatus,
-      name: extractFileName(file),
-      additions,
-      deletions,
-      changes: additions + deletions
-    })
-  }
-
-  console.log(processedFiles)
+  const matches = filename.match(fileExtensionRegex)
+  return matches ? matches[0] : matches
 }
 
 const extractFileName = (file) => {

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -1,5 +1,6 @@
 const minimatch = require('minimatch')
 const { pick, mapKeys, isUndefined } = require('lodash')
+const fetch = require('node-fetch')
 
 const { Validator } = require('./validator')
 const constructOutput = require('./options_processor/options/lib/constructOutput')
@@ -41,7 +42,8 @@ class Size extends Validator {
         deletions: {
           count: 'number',
           message: 'string'
-        }
+        },
+        ignore_comments: 'boolean'
       }
     }
   }
@@ -57,6 +59,8 @@ class Size extends Validator {
     const listFilesResult = await context.github.pulls.listFiles(
       context.repo({pull_number: payload.number})
     )
+
+    await calculateChangesWithoutComments(this.getPayload(context).diff_url)
 
     // Possible file statuses: addded, modified, removed.
     const modifiedFiles = listFilesResult.data
@@ -158,6 +162,60 @@ class Size extends Validator {
 
     return consolidateResult(output, validatorContext)
   }
+}
+
+const calculateChangesWithoutComments = async (url) => {
+  const response = await fetch(url)
+  const diffs = await response.text()
+
+  const files = diffs.split('diff --git')
+  files.shift()
+
+  const processedFiles = []
+
+  for (let file of files) {
+    const lines = file.split('\n')
+
+    if (file.includes('deleted')) continue
+
+    let fileStatus = 'modified'
+    if (file.includes('--- /dev/null')) {
+      fileStatus = 'added'
+    }
+    const addOrDeleteRegex = new RegExp(/^(\+|-)/i)
+    const fileModifierRegex = new RegExp(/(\+\+\+|---)/i)
+
+    let additions = 0
+    let deletions = 0
+    for (let line of lines) {
+      if (addOrDeleteRegex.test(line) && !fileModifierRegex.test(line)) {
+        const lineContent = line.substring(1).trim()
+
+        const plusOrMinus = line[0]
+        if (plusOrMinus === '+') additions++
+        else deletions++
+
+        console.log(lineContent)
+      }
+    }
+
+    processedFiles.push({
+      status: fileStatus,
+      name: extractFileName(file),
+      additions,
+      deletions,
+      changes: additions + deletions
+    })
+  }
+
+  console.log(processedFiles)
+}
+
+const extractFileName = (file) => {
+  const startIndex = file.indexOf('+++ b/')
+  const endIndex = file.indexOf('\n', startIndex)
+
+  return file.substring(startIndex + 6, endIndex)
 }
 
 const matchesIgnoredPatterns = (filename, patternsToIgnore) => (


### PR DESCRIPTION
sample config
```
- do: size
    lines:
      total:
        count: 500
        message: Change is very large. Should be under 500 lines of additions and deletions.
      additions:
        count: 250
        message: Change is very large. Should be under 250 lines of additions
      deletions:
        count: 500
        message: Change is very large. Should be under 250 lines of deletions.
      ignore_comments: false #if true, comments will not be counted toward the lines count
```

closes #245 