### PR TITLE
fix: handle case when content is not found

### DIFF
--- a/__tests__/unit/validators/contents.test.js
+++ b/__tests__/unit/validators/contents.test.js
@@ -76,7 +76,6 @@ test('fail gracefully if content is not found', async () => {
   }
 
   let validation = await contents.processValidate(context, settings)
-  console.log(validation.validations)
   expect(validation.status).toBe('fail')
   expect(validation.validations[0].description).toBe("Failed files : 'package.json (Not Found)'")
 })

--- a/__tests__/unit/validators/contents.test.js
+++ b/__tests__/unit/validators/contents.test.js
@@ -52,6 +52,35 @@ test('files ignore option works correctly', async () => {
   expect(validation.status).toBe('pass')
 })
 
+test('fail gracefully if content is not found', async () => {
+  const context = Helper.mockContext({files: ['package.json']})
+
+  context.github.repos.getContents = jest.fn().mockReturnValue(
+    Promise.reject(
+      new HttpError(
+        '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/repos/contents/#get-contents"}',
+        404,
+        'Not Found')
+    )
+  )
+
+  const contents = new Contents()
+  let settings = {
+    do: 'contents',
+    files: {
+      pr_diff: true
+    },
+    must_exclude: {
+      regex: 'test'
+    }
+  }
+
+  let validation = await contents.processValidate(context, settings)
+  console.log(validation.validations)
+  expect(validation.status).toBe('fail')
+  expect(validation.validations[0].description).toBe("Failed files : 'package.json (Not Found)'")
+})
+
 const createMockContext = (files, fileContent) => {
   const context = Helper.mockContext({files: files})
 
@@ -62,4 +91,14 @@ const createMockContext = (files, fileContent) => {
   }
 
   return context
+}
+
+// to mimic HttpError (https://github.com/octokit/rest.js/blob/fc8960ccf3415b5d77e50372d3bb873cfec80c55/lib/request/http-error.js)
+class HttpError extends Error {
+  constructor (message, code, status) {
+    super(message)
+    this.message = message
+    this.code = code
+    this.status = status
+  }
 }

--- a/lib/validators/contents.js
+++ b/lib/validators/contents.js
@@ -61,6 +61,11 @@ class Contents extends Validator {
     for (let file of changedFiles) {
       const content = await getContent(context, file)
 
+      if (content === null) {
+        failedFiles.push(`${file} (Not Found)`)
+        continue
+      }
+
       const processed = this.processOptions(parseOption, content)
       if (processed.status === 'error') return processed
       if (processed.status === 'fail') failedFiles.push(file)
@@ -87,7 +92,7 @@ const getContent = async (context, path) => {
   })).then(res => {
     return Buffer.from(res.data.content, 'base64').toString()
   }).catch(error => {
-    if (error.status === 404) return null
+    if (error.code === 404) return null
     else throw error
   })
 }

--- a/lib/validators/options_processor/owners.js
+++ b/lib/validators/options_processor/owners.js
@@ -48,7 +48,7 @@ const retrieveCODEOWNER = async (context) => {
   })).then(res => {
     return Buffer.from(res.data.content, 'base64').toString()
   }).catch(error => {
-    if (error.status === 404) return null
+    if (error.code === 404) return null
     else throw error
   })
 }


### PR DESCRIPTION
Address the case in `contents` validator when the content file is not found.

Behavior implemented : 
If content is not found the validator will `fail` and `filename (Not found)` will be added to failed file list 