### PR TITLE
fix: The file should be named CODEOWNERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For convenience, wildcards can be used: `pull_request.*`, `issues.*`, `pull_requ
     message: 'Custom message...'
   required:
     reviewers: [ user1, user2 ] # list of github usernames required to review
-    owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and owners made required reviewers
+    owners: true # Optional boolean. When true, the file .github/CODEOWNERS is read and owners made required reviewers
     assignees: true # Optional boolean. When true, PR assignees are made required reviewers.
     pending_reviewer: true # Optional boolean. When true, all the requested reviewer's approval is required
     message: 'Custom message...'

--- a/__tests__/unit/configuration/transformers/v1Config.test.js
+++ b/__tests__/unit/configuration/transformers/v1Config.test.js
@@ -202,7 +202,7 @@ test('checks all advanced config is transformed accurately', async () => {
           message: 'Custom message...'
         required:
           reviewers: [ user1, user2 ]   # list of github usernames required to review
-          owners: true | false # will read the file .github/CODEOWNER and make them required reviewers
+          owners: true | false # will read the file .github/CODEOWNERS and make them required reviewers
           message: 'Custom message...'
 
       assignee:

--- a/docs/validators/approval.rst
+++ b/docs/validators/approval.rst
@@ -9,7 +9,7 @@ Approvals
         message: 'Custom message...'
       required:
         reviewers: [ user1, user2 ] # list of github usernames required to review
-        owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and owners made required reviewers
+        owners: true # Optional boolean. When true, the file .github/CODEOWNERS is read and owners made required reviewers
         assignees: true # Optional boolean. When true, PR assignees are made required reviewers.
         requested_reviewers: true # Optional boolean. When true, all the requested reviewer's approval is required
         message: 'Custom message...'

--- a/version1.md
+++ b/version1.md
@@ -103,7 +103,7 @@ Here's an example configuration file for advanced settings and all of it's possi
           message: 'Custom message...'
         required:
           reviewers: [ user1, user2 ]   # list of github usernames required to review
-          owners: true | false # will read the file .github/CODEOWNER and make them required reviewers
+          owners: true | false # will read the file .github/CODEOWNERS and make them required reviewers
           message: 'Custom message...'		
 
       description:


### PR DESCRIPTION
GitHub expects `CODEOWNERS` not `CODEOWNER`, according to their documentation

https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners