### PR TITLE
fix: remove edge case described in #330

### DIFF
--- a/lib/configuration/transformers/v2Config.js
+++ b/lib/configuration/transformers/v2Config.js
@@ -34,6 +34,18 @@ const checkAndSetDefault = (ruleSet, defaultValue) => {
 const setPullRequestDefault = (config) => {
   config.mergeable.forEach((recipe) => {
     if (recipe.when.includes('pull_request')) {
+      if (!checkIfDefaultShouldBeApplied(recipe)) {
+        if (recipe.pass === undefined) {
+          recipe.pass = []
+        }
+        if (recipe.fail === undefined) {
+          recipe.fail = []
+        }
+        if (recipe.error === undefined) {
+          recipe.error = []
+        }
+        return
+      }
       recipe.pass = checkAndSetDefault(recipe.pass, consts.DEFAULT_PR_PASS)
       recipe.fail = checkAndSetDefault(recipe.fail, consts.DEFAULT_PR_FAIL)
       recipe.error = checkAndSetDefault(recipe.error, consts.DEFAULT_PR_ERROR)
@@ -50,4 +62,19 @@ const setPullRequestDefault = (config) => {
     }
   })
 }
+
+const checkIfDefaultShouldBeApplied = (recipe) => {
+  if (recipe.pass === undefined && recipe.fail === undefined && recipe.error === undefined) return true
+
+  // if any of the cases include 'check', then others should have `check' default as well, otherwise, don't do anything
+  if (checkIfCheckActionExists(recipe.pass)) return true
+  if (checkIfCheckActionExists(recipe.fail)) return true
+  if (checkIfCheckActionExists(recipe.error)) return true
+}
+
+const checkIfCheckActionExists = (outcome) => {
+  if (_.isUndefined(outcome) || outcome === null) return false
+  return outcome.find(element => element.do === 'checks')
+}
+
 module.exports = V2Config


### PR DESCRIPTION
### Context

Implemented strategy:
if all pass, fail or error are undefined, add default
If either pass, fail or error contain a `checks` action, add the default to others (to support use case where user only want to change one checks case)
else don't apply anything.


 closes #330 