### PR TITLE
fix: processPreAction to only call action relevant to the recipe

### DIFF
--- a/__tests__/unit/flex.test.js
+++ b/__tests__/unit/flex.test.js
@@ -93,6 +93,59 @@ describe('Test processBeforeValidate and processAfterValidate invocations', () =
     expect(action.processBeforeValidate.mock.calls.length).toBe(2)
     expect(action.processAfterValidate.mock.calls.length).toBe(2)
   })
+
+  test('processPreAction works correctly, two whens with same events but different actions', async () => {
+    const config = `
+    version: 2
+    mergeable:
+      - when: pull_request.*
+        validate:
+          - do: title
+            must_exclude:
+              regex: wip|work in progress|do not merge
+              message: 'a custom message'
+          - do: label
+            must_exclude:
+              regex: wip|work in progress
+        fail: 
+          - do: assign
+            assignees: ['test user']
+      - when: pull_request.*
+        validate:
+          - do: title
+            must_exclude:
+              regex: wip|work in progress|do not merge
+              message: 'a custom message'
+          - do: label
+            must_exclude:
+              regex: wip|work in progress
+        pass:
+          - do: comment
+            payload:
+              body: 'test comment'
+          `
+
+    let registry = { validators: new Map(), actions: new Map() }
+    const commentAction = new Action()
+    commentAction.processBeforeValidate = jest.fn()
+    commentAction.processAfterValidate = jest.fn()
+    commentAction.supportedEvents = ['pull_request.opened', 'pull_request.edited', 'pull_request_review.submitted']
+    registry.actions.set('comment', commentAction)
+
+    const assignAction = new Action()
+    assignAction.processBeforeValidate = jest.fn()
+    assignAction.processAfterValidate = jest.fn()
+    assignAction.supportedEvents = ['pull_request.opened', 'pull_request.edited', 'pull_request_review.submitted']
+    registry.actions.set('assign', assignAction)
+
+    Helper.mockConfigWithContext(context, config)
+    context.event = 'pull_request'
+    context.payload.action = 'opened'
+    await executor(context, registry)
+
+    expect(commentAction.processBeforeValidate.mock.calls.length).toBe(1)
+    expect(assignAction.processBeforeValidate.mock.calls.length).toBe(1)
+  })
 })
 
 describe('#executor', () => {

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -7,6 +7,7 @@ const interceptors = require('./interceptors')
 const consolidateResult = require('./validators/options_processor/options/lib/consolidateResults')
 const constructErrorOutput = require('./validators/options_processor/options/lib/constructErrorOutput')
 const logger = require('./logger')
+const _ = require('lodash')
 
 // Main logic Processor of mergeable
 const executeMergeable = async (context, registry) => {
@@ -199,15 +200,29 @@ const processPreActions = async (context, registry, config) => {
 
   config.settings.forEach(rule => {
     if (isEventInContext(rule.when, context)) {
-      registry.actions.forEach(action => {
-        if (action.isEventSupported(`${context.event}.${context.payload.action}`)) {
-          promises.push(action.processBeforeValidate(context, rule, rule.name))
+      // get actions within this rule
+      const actions = extractAllActionFromRecipe(rule)
+      // for each action, do the following
+      actions.forEach(action => {
+        if (registry.actions.get(action).isEventSupported(`${context.event}.${context.payload.action}`)) {
+          promises.push(registry.actions.get(action).processBeforeValidate(context, rule, rule.name))
         }
       })
     }
   })
 
   await Promise.all(promises)
+}
+
+const extractAllActionFromRecipe = (recipe) => {
+  let passActions = recipe.pass.map(action => action.do)
+  let failActions = recipe.fail.map(action => action.do)
+  let errorActions = recipe.error.map(action => action.do)
+
+  let action = _.union(passActions, failActions)
+  action = _.union(action, errorActions)
+
+  return action
 }
 
 const getActionPromises = (context, registry, rule, result) => {


### PR DESCRIPTION
Context

currently, processPreAction execution all actions inside registry for each recipe when it should be that preAction should only be executed if recipe have action as one of the outcomes

closes #337 