### PR TITLE
chore: Upgrade codecov

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "probot-scheduler": "^2.0.0-beta.1"
   },
   "devDependencies": {
-    "codecov": "^3.6.5",
+    "codecov": "^3.7.2",
     "handlebars": "^4.7.6",
     "jest": "^24.0.0",
     "nock": "^11.7.2",


### PR DESCRIPTION
Fixes:
https://snyk.io/vuln/SNYK-JS-CODECOV-585979

We deploy a forked instance of this bot in my org, and we use Snyk.io there which pointed us towards this fix.