### PR TITLE
fix: push event + add fix docs for mergeable 2.0

### DIFF
--- a/docs/actions/check.rst
+++ b/docs/actions/check.rst
@@ -65,9 +65,8 @@ You can pass in Handlebars template to show the details result of the run.
 .. note::
     if any of required fields ``title``, ``summary`` or ``status`` is missing, default values will be used
 
-.. warning::
-    if you have have ``checks`` action only for some of the outcome, you may end up in a state where checks are never finished.
-    So be sure to have ``checks`` for all outcome (``pass``, ``fail``, and ``error``)
+.. note::
+    checks will automatically re-run if the base branch has a modified config file
 
 Supported Events:
 ::

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -92,6 +92,7 @@ Actions that mergeable is currently able to perform.
     actions/check.rst
     actions/close.rst
     actions/comment.rst
+    actions/merge.rst
     actions/label.rst
     actions/request_review.rst
 

--- a/docs/validators/approval.rst
+++ b/docs/validators/approval.rst
@@ -21,13 +21,8 @@ Approvals
         owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and only owners approval will count
 
 .. note::
-    ``owners`` file now support option, make sure to use `@organization/team-slug` format.
+    ``owners`` file now support teams as well, make sure to use `@organization/team-slug` format.
 
-.. warning::
-    ``owners`` sub-option only works in public repos right now, we have plans to enable it for private repos in the future.
-
-.. warning::
-    ``teams`` (both through limit.teams and inside owners file) will not work right now, it require `team:read` permission which mergeable doesn't have, we have plans to request it in the near future.
 
 Supported Events:
 ::

--- a/docs/validators/contents.rst
+++ b/docs/validators/contents.rst
@@ -20,9 +20,6 @@ Contents
          match: 'A String' # or array of strings
          message: 'Come message...'
 
-.. warning::
-    ``merge`` action will not work currently as it require ``contents`` ``read:write`` permission which the mergeable doesn't have. We have plans to enable it in the near future
-
 Supported Events:
 ::
 

--- a/lib/actions/checks.js
+++ b/lib/actions/checks.js
@@ -73,7 +73,8 @@ class Checks extends Action {
       'pull_request.assigned',
       'pull_request.unassigned',
       'pull_request.unlabeled',
-      'pull_request.synchronize'
+      'pull_request.synchronize',
+      'pull_request.push_synchronize'
     ]
     this.checkRunResult = new Map()
   }

--- a/lib/interceptors/push.js
+++ b/lib/interceptors/push.js
@@ -31,7 +31,6 @@ class Push extends Interceptor {
     }))
 
     const pulls = res.data
-
     await Promise.all(pulls.map(pullRequest => {
       const newContext = _.cloneDeep(context)
       newContext.event = 'pull_request'

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -25,7 +25,8 @@ class Approvals extends Validator {
       'pull_request.assigned',
       'pull_request.unassigned',
       'pull_request.unlabeled',
-      'pull_request.synchronize'
+      'pull_request.synchronize',
+      'pull_request.push_synchronize'
     ]
 
     this.supportedSettings = {

--- a/lib/validators/assignee.js
+++ b/lib/validators/assignee.js
@@ -16,6 +16,7 @@ class Assignee extends Validator {
       'pull_request.unassigned',
       'pull_request.unlabeled',
       'pull_request.synchronize',
+      'pull_request.push_synchronize',
       'issues.*'
     ]
 

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -15,7 +15,8 @@ class Changeset extends Validator {
       'pull_request.assigned',
       'pull_request.unassigned',
       'pull_request.unlabeled',
-      'pull_request.synchronize'
+      'pull_request.synchronize',
+      'pull_request.push_synchronize'
     ]
     this.supportedSettings = {
       no_empty: {

--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -24,7 +24,8 @@ class Commit extends Validator {
       'pull_request.assigned',
       'pull_request.unassigned',
       'pull_request.unlabeled',
-      'pull_request.synchronize'
+      'pull_request.synchronize',
+      'pull_request.push_synchronize'
     ]
     this.supportedSettings = {
       message: {

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -20,7 +20,8 @@ class Dependent extends Validator {
       'pull_request.assigned',
       'pull_request.unassigned',
       'pull_request.unlabeled',
-      'pull_request.synchronize'
+      'pull_request.synchronize',
+      'pull_request.push_synchronize'
     ]
     this.supportedSettings = {
       files: 'array',

--- a/lib/validators/description.js
+++ b/lib/validators/description.js
@@ -16,6 +16,7 @@ class Description extends Validator {
       'pull_request.unassigned',
       'pull_request.unlabeled',
       'pull_request.synchronize',
+      'pull_request.push_synchronize',
       'issues.*'
     ]
     this.supportedSettings = {

--- a/lib/validators/label.js
+++ b/lib/validators/label.js
@@ -16,6 +16,7 @@ class Label extends Validator {
       'pull_request.unassigned',
       'pull_request.unlabeled',
       'pull_request.synchronize',
+      'pull_request.push_synchronize',
       'issues.*'
     ]
     this.supportedSettings = {

--- a/lib/validators/milestone.js
+++ b/lib/validators/milestone.js
@@ -17,6 +17,7 @@ class Milestone extends Validator {
       'pull_request.unassigned',
       'pull_request.unlabeled',
       'pull_request.synchronize',
+      'pull_request.push_synchronize',
       'issues.*'
     ]
     this.supportedSettings = {

--- a/lib/validators/options_processor/teams.js
+++ b/lib/validators/options_processor/teams.js
@@ -4,6 +4,9 @@ const _ = require('lodash')
 class Teams {
   static async extractTeamMembers (context, teams) {
     let teamMembers = []
+
+    if (!teams || teams.length === 0) return teamMembers
+
     for (let team of teams) {
       let members = []
       try {

--- a/lib/validators/project.js
+++ b/lib/validators/project.js
@@ -20,6 +20,7 @@ class Project extends Validator {
       'pull_request.unassigned',
       'pull_request.unlabeled',
       'pull_request.synchronize',
+      'pull_request.push_synchronize',
       'issues.*'
     ]
     this.supportedSettings = {

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -39,7 +39,8 @@ class Size extends Validator {
       'pull_request.assigned',
       'pull_request.unassigned',
       'pull_request.unlabeled',
-      'pull_request.synchronize'
+      'pull_request.synchronize',
+      'pull_request.push_synchronize'
     ]
     this.supportedSettings = {
       ignore: 'array',

--- a/lib/validators/title.js
+++ b/lib/validators/title.js
@@ -16,6 +16,7 @@ class Title extends Validator {
       'pull_request.unassigned',
       'pull_request.unlabeled',
       'pull_request.synchronize',
+      'pull_request.push_synchronize',
       'issues.*'
     ]
     this.supportedSettings = {


### PR DESCRIPTION
A few fixes to prepare for mergeable 2.0

- Push event was missing `pull_request.push_synchronize` in supported events
- remove mentions of permissions needed