### PR TITLE
fix: some push event doesn't have `head_commit` property

### DIFF
--- a/lib/interceptors/push.js
+++ b/lib/interceptors/push.js
@@ -13,6 +13,9 @@ class Push extends Interceptor {
   async process (context) {
     if (context.event !== 'push') return context
 
+    // if there is no head_commit, just skip
+    if (_.isUndefined(context.payload.head_commit)) return context
+
     const addedFiles = context.payload.head_commit.added
     const modifiedFiles = context.payload.head_commit.modified
 


### PR DESCRIPTION
context
some of the push event doesn't have `head_commit` property, for those we can just skip it