### PR TITLE
fix: push interceptor - part 2

### DIFF
--- a/__tests__/unit/interceptors/push.test.js
+++ b/__tests__/unit/interceptors/push.test.js
@@ -58,12 +58,13 @@ describe('push interceptor test', () => {
     expect(processWorkflow.mock.calls[0][0].payload.pull_request).toBe('PR1')
   })
 
-  test('do nothing if `head_commit` property does not exist', async () => {
+  test('do nothing if `head_commit` property is null', async () => {
     let push = new Push()
     let context = mockContextWithConfig(CONFIG_STRING, ['PR1'])
 
     context.github.pulls.get.mockReturnValue({ data: { number: 456 } })
     context.event = 'push'
+    context.payload.head_commit = null
 
     let newContext = await push.process(context)
     expect(newContext.event).toBe('push')

--- a/__tests__/unit/interceptors/push.test.js
+++ b/__tests__/unit/interceptors/push.test.js
@@ -57,6 +57,18 @@ describe('push interceptor test', () => {
     expect(processWorkflow.mock.calls[0][0].payload.action).toBe('push_synchronize')
     expect(processWorkflow.mock.calls[0][0].payload.pull_request).toBe('PR1')
   })
+
+  test('do nothing if `head_commit` property does not exist', async () => {
+    let push = new Push()
+    let context = mockContextWithConfig(CONFIG_STRING, ['PR1'])
+
+    context.github.pulls.get.mockReturnValue({ data: { number: 456 } })
+    context.event = 'push'
+
+    let newContext = await push.process(context)
+    expect(newContext.event).toBe('push')
+    expect(processWorkflow.mock.calls.length).toBe(0)
+  })
 })
 
 const mockContextWithConfig = (config, list) => {

--- a/lib/interceptors/push.js
+++ b/lib/interceptors/push.js
@@ -14,7 +14,7 @@ class Push extends Interceptor {
     if (context.event !== 'push') return context
 
     // if there is no head_commit, just skip
-    if (_.isUndefined(context.payload.head_commit)) return context
+    if (_.isUndefined(context.payload.head_commit) || !context.payload.head_commit) return context
 
     const addedFiles = context.payload.head_commit.added
     const modifiedFiles = context.payload.head_commit.modified


### PR DESCRIPTION
fix for push interceptor throwing `can't find 'added' of null` error