### PR TITLE
feat: display file processed in size validator

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| Aug 24, 2020: display files processed in `size` validator `#366 <https://github.com/mergeability/mergeable/issues/366>`_
 | July 28, 2020 : owners file now support teams and limit.owners option added in `approvals` validator `#331 <https://github.com/mergeability/mergeable/issues/331>`_
 | July 12, 2020 : Allow usage of special annotation `@author` in comments and checks `#328 <https://github.com/mergeability/mergeable/issues/328>`_
 | July 1, 2020 : When config file is added/modified in base branch, mergeable will trigger for all PR against the base branch `#153 <https://github.com/mergeability/mergeable/issues/153>`_

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -110,7 +110,8 @@ class Size extends Validator {
       prSizeChanges.total += file.changes
     })
 
-    const inputMessage = `${prSizeChanges.total} total, ${prSizeChanges.additions} additions, ${prSizeChanges.deletions} deletions`
+    const inputMessage = `${prSizeChanges.total} total, ${prSizeChanges.additions} additions, ${prSizeChanges.deletions} deletions
+    Files: ${modifiedFiles.map(file => file.filename).join(',')}`
 
     if (!validationSettings.lines) {
       return consolidateResult(


### PR DESCRIPTION
Add list of processed files in size validator's display
![image](https://user-images.githubusercontent.com/5243508/91080906-3c555a00-e5fb-11ea-99d9-d35f37682c2f.png)

closes #366 
