### PR TITLE
docs: Fix changelog references

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,13 +1,13 @@
 CHANGELOG
 =====================================
 
-| September 17, 2020 : Add support for `schedule.repository` event for`labels` and `close` actions `#379 <https://github.com/mergeability/mergeable/issues/379>`_
+| September 17, 2020 : Add support for `schedule.repository` event for`labels` and `close` actions `#377 <https://github.com/mergeability/mergeable/issues/377>`_
 | September 17, 2020 : Fix the comment action to work correctly with the scheduler `#376 <https://github.com/mergeability/mergeable/issues/376>`_
-| September 16, 2020 : Allow specifying files to `match` for the `size` validator `#373 <https://github.com/mergeability/mergeable/issues/373>`_
+| September 16, 2020 : Allow specifying files to `match` for the `size` validator `#371 <https://github.com/mergeability/mergeable/issues/371>`_
 | September 16, 2020 : `stale` validator now supports optionally skipping items associated with a `project` or a `milestone` `#375 <https://github.com/mergeability/mergeable/issues/375>`_
 | September 16, 2020 : `stale` validator now supports labels for `match` or `ignore` `#372 <https://github.com/mergeability/mergeable/issues/372>`_
-| Aug 24, 2020: display files processed in `size` validator `#366 <https://github.com/mergeability/mergeable/issues/366>`_
-| Aug 17, 2020: fix Error string in `merge failed` error
+| August 24, 2020: display files processed in `size` validator `#366 <https://github.com/mergeability/mergeable/issues/366>`_
+| August 17, 2020: fix Error string in `merge failed` error
 | July 28, 2020 : owners file now support teams and limit.owners option added in `approvals` validator `#331 <https://github.com/mergeability/mergeable/issues/331>`_
 | July 12, 2020 : Allow usage of special annotation `@author` in comments and checks `#328 <https://github.com/mergeability/mergeable/issues/328>`_
 | July 1, 2020 : When config file is added/modified in base branch, mergeable will trigger for all PR against the base branch `#153 <https://github.com/mergeability/mergeable/issues/153>`_


### PR DESCRIPTION
Some of my PRs had wrong issue references in the change log. Also makes the months consistent? 