### PR TITLE
fix: don't throw error if required status is not done

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| October 2, 2020 : Don't throw merge error if required status are are the cause of the error `#389 <https://github.com/mergeability/mergeable/issues/389>`_
 | September 24, 2020 : Add ability to delete or replace the labels on an issue `#380 <https://github.com/mergeability/mergeable/issues/380>`_
 | September 22, 2020 : Allow support for customizing the scheduler interval via an enviroment variable `MERGEABLE_SCHEDULER_INTERVAL` `#383 <https://github.com/mergeability/mergeable/issues/383>`_
 | September 17, 2020 : Add support for `schedule.repository` event for`labels` and `close` actions `#377 <https://github.com/mergeability/mergeable/issues/377>`_

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -52,6 +52,10 @@ class Merge extends Action {
         // skip on known errors
         // 405 === Method not allowed , 409 === Conflict
         if (err.status === 405 || err.status === 409) {
+          // if the error is another required status check, just skip
+          // no easy way to check if all required status are done
+          if (err.message.includes('Required status check')) return
+
           throw new Error(`Merge failed! error : ${err}`)
         } else {
           throw err


### PR DESCRIPTION
There weren't any API to check if all required status is done so the solution implemented here is to just not throw error if we see this specific type of error
