### PR TITLE
[wip] feat: Add the ability to auto merge PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
-      - image: circleci/node:8.8.1 # ...with this image as the primary container; this is where all `steps` will run
+      - image: circleci/node:13.11.0 # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout # special step to check out source code to working directory
       # - run:

--- a/__tests__/unit/actions/merge.test.js
+++ b/__tests__/unit/actions/merge.test.js
@@ -5,6 +5,7 @@ test('check that merge is called if PR has not been merged', async () => {
   const merge = new Merge()
   const checkIfMerged = false
   const context = Helper.mockContext({ checkIfMerged })
+  context.github.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean' } })
   const settings = {}
 
   await merge.afterValidate(context, settings)
@@ -16,6 +17,7 @@ test('check that merge is not called if PR has not been merged', async () => {
   const merge = new Merge()
   const checkIfMerged = true
   const context = Helper.mockContext({ checkIfMerged })
+  context.github.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean' } })
   const settings = {}
 
   await merge.afterValidate(context, settings)
@@ -26,6 +28,7 @@ test('check that merge_method option works correctly', async () => {
   const merge = new Merge()
   const checkIfMerged = false
   const context = Helper.mockContext({ checkIfMerged })
+  context.github.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean' } })
   const settings = {
     merge_method: 'squash'
   }

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -22,11 +22,36 @@ const checkIfMerged = async (context, prNumber) => {
   return status
 }
 
+const mergePR = async (context, prNumber, mergeMethod) => {
+  const isMerged = await checkIfMerged(context, prNumber)
+
+  if (!isMerged) {
+    const pullRequest = await context.github.pulls.get(context.repo({ pull_number: prNumber }))
+    if (pullRequest.data.mergeable_state && pullRequest.data.mergeable_state === 'blocked') return
+    try {
+      await context.github.pulls.merge(context.repo({ pull_number: prNumber, merge_method: mergeMethod }))
+    } catch (err) {
+      // skip on known errors
+      // 405 === Method not allowed , 409 === Conflict
+      if (err.status === 405 || err.status === 409) {
+        // if the error is another required status check, just skip
+        // no easy way to check if all required status are done
+        if (err.message.includes('Required status check')) return
+
+        throw new Error(`Merge failed! error : ${err}`)
+      } else {
+        throw err
+      }
+    }
+  }
+}
+
 class Merge extends Action {
   constructor () {
     super('merge')
     this.supportedEvents = [
-      'pull_request.*'
+      'pull_request.*',
+      'status.*'
     ]
 
     this.supportedSettings = {
@@ -37,31 +62,22 @@ class Merge extends Action {
   // there is nothing to do
   async beforeValidate () {}
 
-  async afterValidate (context, settings, results) {
-    const prNumber = this.getPayload(context).number
-    const isMerged = await checkIfMerged(context, prNumber)
-
-    if (!isMerged) {
-      if (settings.merge_method && !MERGE_METHOD_OPTIONS.includes(settings.merge_method)) {
-        throw new UnSupportedSettingError(`Unknown Merge method, supported options are ${MERGE_METHOD_OPTIONS.join(', ')}`)
-      }
-      let mergeMethod = settings.merge_method ? settings.merge_method : 'merge'
-      try {
-        await context.github.pulls.merge(context.repo({ pull_number: prNumber, merge_method: mergeMethod }))
-      } catch (err) {
-        // skip on known errors
-        // 405 === Method not allowed , 409 === Conflict
-        if (err.status === 405 || err.status === 409) {
-          // if the error is another required status check, just skip
-          // no easy way to check if all required status are done
-          if (err.message.includes('Required status check')) return
-
-          throw new Error(`Merge failed! error : ${err}`)
-        } else {
-          throw err
-        }
-      }
+  async afterValidate (context, settings, name, results) {
+    if (settings.merge_method && !MERGE_METHOD_OPTIONS.includes(settings.merge_method)) {
+      throw new UnSupportedSettingError(`Unknown Merge method, supported options are ${MERGE_METHOD_OPTIONS.join(', ')}`)
     }
+    let mergeMethod = settings.merge_method ? settings.merge_method : 'merge'
+
+    let relatedPullRequests = (results && results.validationSuites && results.validationSuites[0].details.input.relatedPullRequests) || [this.getPayload(context)]
+    return Promise.all(
+      relatedPullRequests.map(issue => {
+        mergePR(
+          context,
+          issue.number,
+          mergeMethod
+        )
+      })
+    )
   }
 }
 

--- a/lib/validators/status.js
+++ b/lib/validators/status.js
@@ -1,0 +1,36 @@
+const { Validator } = require('./validator')
+const constructOutput = require('./options_processor/options/lib/constructOutput')
+
+const MAX_ISSUES = 20 // max issues to retrieve each time.
+
+class Status extends Validator {
+  constructor () {
+    super('status')
+    this.supportedEvents = [
+      'status.*'
+    ]
+    this.supportedSettings = {
+      'checks': 'string'
+    }
+  }
+
+  async validate (context, validationSettings, registry) {
+    let commitSHA = context.payload['sha']
+    let statusQuery = validationSettings.checks === 'all' ? 'status:success' : ''
+    let results = await context.github.search.issuesAndPullRequests({
+      q: `repo:${context.repo().owner}/${context.repo().repo} is:open ${commitSHA} ${statusQuery}`.trim(),
+      sort: 'updated',
+      order: 'desc',
+      per_page: MAX_ISSUES
+    })
+    let relatedPullRequests = results.data.items.filter(item => item.pull_request)
+    let status = relatedPullRequests.length > 0 ? 'pass' : 'fail'
+    const result = {
+      status: status,
+      description: `Related PRs - ${relatedPullRequests.size}`
+    }
+    return constructOutput({name: 'Status'}, {relatedPullRequests}, validationSettings, result)
+  }
+}
+
+module.exports = Status


### PR DESCRIPTION
This PR adds a couple of things - 

1. A new event type listener for `status.*` this allows us to listen to status change events so that we can fire the `merge` action on `status` change events.
2. A validator for `status.*`. This validator resolves the commit related to the status to relevant PRs on the repository. There is a `checks` setting option it takes to filter our PRs with failing checks. (This is optional as some checks may not be required to do merge)
3. Adds support for status* events to the merge actions.
4. Checks that the pull request is not in a `blocked` `mergeable_state` before trying to merge. This ensures that the PR is ready to merge (passes required checks including status, review and other branch protection checks)
5. Fixes broken `merge` action. `merge` action was missing the `name` parameter.

Fixes #395 

Fixes #386 

TODO: Update docs and add tests.