### PR TITLE
fix(docs): header in labels action doc

### DIFF
--- a/docs/actions/labels.rst
+++ b/docs/actions/labels.rst
@@ -1,4 +1,4 @@
-label
+Labels
 ^^^^^^^^
 
 You can also add a set of the labels on an item

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| October 5, 2020 : fix Typo in header of labels action docs and corresponding rst file
 | October 4, 2020 : fix Typo in header of title validator docs
 | October 2, 2020 : Don't throw merge error if required status are are the cause of the error `#389 <https://github.com/mergeability/mergeable/issues/389>`_
 | September 24, 2020 : Add ability to delete or replace the labels on an issue `#380 <https://github.com/mergeability/mergeable/issues/380>`_

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -93,7 +93,7 @@ Actions that mergeable is currently able to perform.
     actions/close.rst
     actions/comment.rst
     actions/merge.rst
-    actions/label.rst
+    actions/labels.rst
     actions/request_review.rst
 
 .. _organisation-wide-defaults:


### PR DESCRIPTION
The name of the action is 'labels' to be contrasted with the name of
the validator which is 'label'.
The filename for the doc is modified accordingly as well.