### PR TITLE
feat: Add the ability to auto-merge pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
-      - image: circleci/node:8.8.1 # ...with this image as the primary container; this is where all `steps` will run
+      - image: circleci/node:12.16.0 # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout # special step to check out source code to working directory
       # - run:

--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -13,9 +13,17 @@ module.exports = {
       repo: (properties) => { return Object.assign({ owner: 'owner', repo: 'repo' }, properties) },
       event: (options.event) ? options.event : 'pull_request',
       payload: {
+        sha: 'sha1',
         action: 'opened',
         repository: {
           full_name: 'name'
+        },
+        check_suite: {
+          pull_requests: [
+            {
+              number: 1
+            }
+          ]
         },
         pull_request: {
           user: {

--- a/__tests__/unit/actions/merge.test.js
+++ b/__tests__/unit/actions/merge.test.js
@@ -13,6 +13,48 @@ test('check that merge is called if PR has not been merged', async () => {
   expect(context.github.pulls.merge.mock.calls[0][0].merge_method).toBe('merge')
 })
 
+test('check that merge is called for review events', async () => {
+  const merge = new Merge()
+  const checkIfMerged = false
+  const context = Helper.mockContext({ checkIfMerged, event: 'pull_request_review' })
+  context.github.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean', state: 'open' } })
+  const settings = {}
+
+  await merge.afterValidate(context, settings)
+  expect(context.github.pulls.merge.mock.calls.length).toBe(1)
+  expect(context.github.pulls.merge.mock.calls[0][0].merge_method).toBe('merge')
+})
+
+test('check that merge is called for status events', async () => {
+  const merge = new Merge()
+  const checkIfMerged = false
+  const context = Helper.mockContext({ checkIfMerged, event: 'status' })
+  context.github.search = {
+    issuesAndPullRequests: jest.fn().mockReturnValue({
+      data: { items: [{pull_request: true, number: 1}, {pull_request: false, number: 2}] }
+    })
+  }
+  context.github.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean', state: 'open' } })
+  const settings = {}
+
+  await merge.afterValidate(context, settings)
+  expect(context.github.search.issuesAndPullRequests.mock.calls.length).toBe(1)
+  expect(context.github.pulls.merge.mock.calls.length).toBe(1)
+  expect(context.github.pulls.merge.mock.calls[0][0].merge_method).toBe('merge')
+})
+
+test('check that merge is called for check suite events', async () => {
+  const merge = new Merge()
+  const checkIfMerged = false
+  const context = Helper.mockContext({ checkIfMerged, event: 'check_suite' })
+  context.github.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean', state: 'open' } })
+  const settings = {}
+
+  await merge.afterValidate(context, settings)
+  expect(context.github.pulls.merge.mock.calls.length).toBe(1)
+  expect(context.github.pulls.merge.mock.calls[0][0].merge_method).toBe('merge')
+})
+
 test('check that merge is not called if PR is in a blocked state', async () => {
   const merge = new Merge()
   const checkIfMerged = false

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| October 11, 2020 : feat: Add the ability to auto-merge pull requests `#395 <https://github.com/mergeability/mergeable/issues/395>`_
 | October 6, 2020 : fix: Size validator - do not ignore hidden files by default `#401 <https://github.com/mergeability/mergeable/issues/401>`_
 | October 6, 2020 : Do not attempt to merge a pull request if the status is blocked `#389 <https://github.com/mergeability/mergeable/issues/389>`_
 | October 6, 2020 : fix: Fix undefined error with blank validators `#402 <https://github.com/mergeability/mergeable/issues/402>`_

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -139,7 +139,28 @@ Add a comment on a pull request when it is created
         name: "Greet a contributor"
         validate: []
         pass:
-        - do: comment
-          payload:
-              body: >
-              Thanks for creating a pull request! A maintainer will review your changes shortly. Please don't be discouraged if it takes a while.
+          - do: comment
+            payload:
+                body: >
+                Thanks for creating a pull request! A maintainer will review your changes shortly. Please don't be discouraged if it takes a while.
+
+
+Auto-merge pull requests once all checks pass
+"""""""""""""""""""""""""""""""""""""""""""""
+This recipe relies on the fact that the main branch has been protected and only allows merges
+when the required checks have passed or the required number of reviews/other conditions are met.
+This basically means that ``mergeable`` will merge the pull request as soon as it shows a green merged button
+on Github.
+
+Notice the blank validator which ensures that the merge event happens as soon as Github allows ``mergeable`` to merge the pull request.
+
+::
+
+    version: 2
+    mergeable:
+      - when: pull_request.*, pull_request_review.*, status.*, check_suite.*
+        name: "Automatically merge pull requests once it passes all checks"
+        validate: []
+        pass:
+          - do: merge
+            merge_method: "squash"

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -50,7 +50,10 @@ class Merge extends Action {
   constructor () {
     super('merge')
     this.supportedEvents = [
-      'pull_request.*'
+      'pull_request.*',
+      'pull_request_review.*',
+      'status.*',
+      'check_suite.*'
     ]
 
     this.supportedSettings = {
@@ -66,10 +69,29 @@ class Merge extends Action {
       throw new UnSupportedSettingError(`Unknown Merge method, supported options are ${MERGE_METHOD_OPTIONS.join(', ')}`)
     }
     let mergeMethod = settings.merge_method ? settings.merge_method : 'merge'
-    return mergePR(
-      context,
-      this.getPayload(context).number,
-      mergeMethod
+    let relatedPullRequests = []
+    if (context.event === 'status') {
+      let commitSHA = context.payload['sha']
+      let results = await context.github.search.issuesAndPullRequests({
+        q: `repo:${context.repo().owner}/${context.repo().repo} is:open ${commitSHA}`.trim(),
+        sort: 'updated',
+        order: 'desc',
+        per_page: 20
+      })
+      relatedPullRequests = results.data.items.filter(item => item.pull_request)
+    } else if (context.event === 'check_suite') {
+      relatedPullRequests = this.getPayload(context).pull_requests
+    } else {
+      relatedPullRequests = [this.getPayload(context)]
+    }
+    return Promise.all(
+      relatedPullRequests.map(issue => {
+        mergePR(
+          context,
+          issue.number,
+          mergeMethod
+        )
+      })
     )
   }
 }


### PR DESCRIPTION
Fixes #395 

Better version of #394 

We need to add support for both `status.*` events and `check_suite.*` events since the former is used by CI like Jenkins/Circle CI and the latter is used by apps like `mergeable` and Github Actions.