### PR TITLE
feat: Helm Chart implemantation for kubernetes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ CHANGELOG
 =====================================
 
 
+| December 11, 2020 : feat: Helm Chart implemantation for kubernetes `#435 <https://github.com/mergeability/mergeable/issues/435>`_
 | October 20, 2020 : feat: Add a config cache which can be enabled via MERGEABLE_ENABLE_CONFIG_CACHE env var `#407 <https://github.com/mergeability/mergeable/issues/407>`_
 | October 15, 2020 : feat: Add the ability to auto-merge pull requests `#395 <https://github.com/mergeability/mergeable/issues/395>`_
 | October 8, 2020 : feat: added BaseRef-validator to enforce stricter rules on certain branches `#343 <https://github.com/mergeability/mergeable/issues/343>`_

--- a/helm/mergeable/.helmignore
+++ b/helm/mergeable/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/mergeable/Chart.yaml
+++ b/helm/mergeable/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: mergeable
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/helm/mergeable/templates/NOTES.txt
+++ b/helm/mergeable/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mergeable.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mergeable.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mergeable.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mergeable.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm/mergeable/templates/_helpers.tpl
+++ b/helm/mergeable/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mergeable.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mergeable.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mergeable.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mergeable.labels" -}}
+helm.sh/chart: {{ include "mergeable.chart" . }}
+{{ include "mergeable.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mergeable.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mergeable.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mergeable.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mergeable.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/mergeable/templates/deployment.yaml
+++ b/helm/mergeable/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mergeable.fullname" . }}
+  labels:
+    {{- include "mergeable.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "mergeable.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "mergeable.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mergeable.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/mergeable/templates/deployment.yaml
+++ b/helm/mergeable/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
             {{- else }}
             value: {{ $envValue | quote }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.ContainerPort}}

--- a/helm/mergeable/templates/deployment.yaml
+++ b/helm/mergeable/templates/deployment.yaml
@@ -55,11 +55,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /probot
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /probot
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/mergeable/templates/deployment.yaml
+++ b/helm/mergeable/templates/deployment.yaml
@@ -33,6 +33,21 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- range $envName, $envValue := .Values.ContainerEnvs }}
+          - name: {{ $envName }}
+            {{- if eq (printf "%T" $envValue) "map[string]interface {}" }}
+            valueFrom:
+              {{ $envValue.type }}:
+                {{- if $envValue.prefixFullName }}
+                name: {{ template "<CHARTNAME>.fullname" $ }}{{ $envValue.name }}
+                {{- else }}
+                name: {{ $envValue.name }}
+                {{- end }}
+                key: {{ $envValue.key }}
+            {{- else }}
+            value: {{ $envValue | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.ContainerPort}}

--- a/helm/mergeable/templates/deployment.yaml
+++ b/helm/mergeable/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.ContainerPort}}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/mergeable/templates/hpa.yaml
+++ b/helm/mergeable/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mergeable.fullname" . }}
+  labels:
+    {{- include "mergeable.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mergeable.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/helm/mergeable/templates/ingress.yaml
+++ b/helm/mergeable/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mergeable.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mergeable.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm/mergeable/templates/namespace.yaml
+++ b/helm/mergeable/templates/namespace.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.namespace.enabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "mergeable.fullname" . }}
+  {{- with .Values.namespace.annotations }}
+  annotations: {{- toYaml . | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/helm/mergeable/templates/namespace.yaml
+++ b/helm/mergeable/templates/namespace.yaml
@@ -6,4 +6,7 @@ metadata:
   {{- with .Values.namespace.annotations }}
   annotations: {{- toYaml . | nindent 8 }}
   {{- end }}
+   {{- with .Values.namespace.labels }}
+  labels: {{- toYaml . | nindent 8 }}
+  {{- end }}
 {{- end }}

--- a/helm/mergeable/templates/service.yaml
+++ b/helm/mergeable/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mergeable.fullname" . }}
+  labels:
+    {{- include "mergeable.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mergeable.selectorLabels" . | nindent 4 }}

--- a/helm/mergeable/templates/serviceaccount.yaml
+++ b/helm/mergeable/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mergeable.serviceAccountName" . }}
+  labels:
+    {{- include "mergeable.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/mergeable/templates/tests/test-connection.yaml
+++ b/helm/mergeable/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mergeable.fullname" . }}-test-connection"
+  labels:
+    {{- include "mergeable.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "mergeable.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -10,7 +10,7 @@ namespace:
   labels: {}
 
 image:
-  repository: 489198589229.dkr.ecr.eu-west-1.amazonaws.com/mergeable
+  repository: "DOCKER_REPO/mergeable"
   pullPolicy: IfNotPresent
   tag: ""
 

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -1,0 +1,79 @@
+# Default values for mergeable.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -10,6 +10,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+ContainerPort: 3000
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 1
 namespace:
   enabled: true
   annotations: {}
+  labels: {}
 
 image:
   repository: 489198589229.dkr.ecr.eu-west-1.amazonaws.com/mergeable

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -15,6 +15,7 @@ image:
   tag: ""
 
 ContainerPort: 3000
+ContainerEnvs: {}
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -4,10 +4,13 @@
 
 replicaCount: 1
 
+namespace:
+  enabled: true
+  annotations: {}
+
 image:
-  repository: nginx
+  repository: 489198589229.dkr.ecr.eu-west-1.amazonaws.com/mergeable
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 ContainerPort: 3000


### PR DESCRIPTION
Fixes : https://github.com/mergeability/mergeable/issues/435

**Problem:**

There is no easy way to install Mergeable into the Kubernetes cluster.

**Solution:**

This PR implements a helm-chart to install mergeable into the Kubernetes cluster.