### PR TITLE
feat: Add env to control which configuration file to use

### DIFF
--- a/__tests__/unit/configuration/configuration.test.js
+++ b/__tests__/unit/configuration/configuration.test.js
@@ -665,6 +665,34 @@ describe('with version 1', () => {
     expect(config.settings[0].fail).toBeDefined()
     expect(config.settings[0].error).toBeDefined()
   })
+
+  test('that fetchConfigFile returns the right Configuration depending on USE_CONFIG_FROM_PULL_REQUEST env', async () => {
+    let configString = `
+          mergeable:
+            issues:
+              stale:
+                days: 20
+                message: From HEAD Config
+        `
+    let prConfigString = `
+          mergeable:
+            issues:
+              stale:
+                days: 20
+                message: From PR Config
+        `
+    let files = {files: [
+      { filename: '.github/mergeable.yml', status: 'modified' }
+    ]}
+
+    let context = createMockGhConfig(configString, prConfigString, files)
+    context.event = 'pull_request'
+
+    process.env.USE_CONFIG_FROM_PULL_REQUEST = 'false'
+    let config = await Configuration.fetchConfigFile(context)
+    let parsedConfig = yaml.safeLoad(configString)
+    expect(config).toEqual(parsedConfig)
+  })
 })
 
 // helper method to return mocked configiration.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ CHANGELOG
 =====================================
 
 
+| December 11, 2020 : feat: Add env to control which configuration file to use `#429 <https://github.com/mergeability/mergeable/issues/429>`_
 | October 20, 2020 : feat: Add a config cache which can be enabled via MERGEABLE_ENABLE_CONFIG_CACHE env var `#407 <https://github.com/mergeability/mergeable/issues/407>`_
 | October 15, 2020 : feat: Add the ability to auto-merge pull requests `#395 <https://github.com/mergeability/mergeable/issues/395>`_
 | October 8, 2020 : feat: added BaseRef-validator to enforce stricter rules on certain branches `#343 <https://github.com/mergeability/mergeable/issues/343>`_

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -112,7 +112,13 @@ class Configuration {
   static async fetchConfigFile (context) {
     let github = context.github
     let repo = context.repo()
-    if (['pull_request', 'pull_request_review'].includes(context.event)) {
+    // using pull request configuration by default, this behaviour
+    // can be controlled using USE_CONFIG_FROM_PULL_REQUEST environment variable
+    let usePullRequestConfig = true
+    if (process.env.USE_CONFIG_FROM_PULL_REQUEST !== undefined && process.env.USE_CONFIG_FROM_PULL_REQUEST === 'false') {
+      usePullRequestConfig = false
+    }
+    if (usePullRequestConfig && ['pull_request', 'pull_request_review'].includes(context.event)) {
       let payload = context.payload['pull_request']
       // If the pull request is from a fork, don't read the config as it
       // may be malicious


### PR DESCRIPTION
Fixes: #429

**Problem:**
Currently there is no way to control which mergeable configuration file will be used, if the one from the PR branch or the one from the default branch.

**Solution:**
This PR implements a new environment variable to control that while maintaining the previous behaviour