### PR TITLE
feat: headref validator

### DIFF
--- a/__tests__/unit/validators/headRef.test.js
+++ b/__tests__/unit/validators/headRef.test.js
@@ -1,0 +1,67 @@
+const HeadRef = require('../../../lib/validators/headRef')
+const Helper = require('../../../__fixtures__/unit/helper')
+
+test('fail gracefully if invalid regex', async () => {
+  const headRef = new HeadRef()
+
+  const settings = {
+    do: 'headRef',
+    must_exclude: {
+      regex: '@#$@#$@#$'
+    }
+  }
+
+  const headRefValidation = await headRef.processValidate(mockContext('WIP HeadRef'), settings)
+  expect(headRefValidation.status).toBe('pass')
+})
+
+test('checks that it fail when exclude regex is in headRef', async () => {
+  const headRef = new HeadRef()
+
+  const settings = {
+    do: 'headRef',
+    must_include: {
+      regex: '^\\(feat\\)|^\\(doc\\)|^\\(fix\\)'
+    },
+    must_exclude: {
+      regex: 'wip'
+    }
+  }
+
+  let headRefValidation = await headRef.processValidate(mockContext('WIP HeadRef'), settings)
+  expect(headRefValidation.status).toBe('fail')
+
+  headRefValidation = await headRef.processValidate(mockContext('(feat) WIP HeadRef'), settings)
+  expect(headRefValidation.status).toBe('fail')
+})
+
+test('checks that advance setting of must_include works', async () => {
+  const headRef = new HeadRef()
+
+  const includeList = '`^\\(feat\\)|^\\(doc\\)|^\\(fix\\)`'
+  const testMessage = 'this is a test message'
+
+  const settings = {
+    do: 'headRef',
+    must_include: {
+      regex: includeList,
+      message: testMessage
+    },
+    must_exclude: {
+      regex: 'wip'
+    }
+  }
+
+  let headRefValidation = await headRef.processValidate(mockContext('include HeadRef'), settings)
+  expect(headRefValidation.status).toBe('fail')
+  expect(headRefValidation.validations[0].description).toBe(testMessage)
+
+  headRefValidation = await headRef.processValidate(mockContext('(feat) WIP HeadRef'), settings)
+
+  expect(headRefValidation.status).toBe('fail')
+})
+
+const mockContext = headRef => {
+  const context = Helper.mockContext({ headRef: headRef })
+  return context
+}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ CHANGELOG
 =====================================
 
 
+| December 14, 2020 : feat: Add branch validator `#438 <https://github.com/mergeability/mergeable/issues/438>`_
 | October 20, 2020 : feat: Add a config cache which can be enabled via MERGEABLE_ENABLE_CONFIG_CACHE env var `#407 <https://github.com/mergeability/mergeable/issues/407>`_
 | October 15, 2020 : feat: Add the ability to auto-merge pull requests `#395 <https://github.com/mergeability/mergeable/issues/395>`_
 | October 8, 2020 : feat: added BaseRef-validator to enforce stricter rules on certain branches `#343 <https://github.com/mergeability/mergeable/issues/343>`_

--- a/lib/validators/headRef.js
+++ b/lib/validators/headRef.js
@@ -1,7 +1,7 @@
 const { Validator } = require('./validator')
 
 class HeadRef extends Validator {
-  constructor() {
+  constructor () {
     super('headRef')
     this.supportedEvents = [
       'pull_request.*',
@@ -21,7 +21,7 @@ class HeadRef extends Validator {
     }
   }
 
-  async validate(context, validationSettings) {
+  async validate (context, validationSettings) {
     return this.processOptions(
       validationSettings,
       this.getPayload(context).head.ref

--- a/lib/validators/headRef.js
+++ b/lib/validators/headRef.js
@@ -1,0 +1,32 @@
+const { Validator } = require('./validator')
+
+class HeadRef extends Validator {
+  constructor() {
+    super('headRef')
+    this.supportedEvents = [
+      'pull_request.*',
+      'pull_request_review.*'
+    ]
+    this.supportedSettings = {
+      must_include: {
+        regex: 'string',
+        regex_flag: 'string',
+        message: 'string'
+      },
+      must_exclude: {
+        regex: 'string',
+        regex_flag: 'string',
+        message: 'string'
+      }
+    }
+  }
+
+  async validate(context, validationSettings) {
+    return this.processOptions(
+      validationSettings,
+      this.getPayload(context).head.ref
+    )
+  }
+}
+
+module.exports = HeadRef


### PR DESCRIPTION
Issue: https://github.com/mergeability/mergeable/issues/438

---

With this PR, developers can validate headRef (branch) with regex tags.

Sample:

```
- do: headRef
        must_include:
           regex: '(^|[-\/])(major|release|minor|feature|patch|issue|hotfix|dependabot\/|whitesource)[-\/](\b[A-Z][A-Z0-9]+-\d+\b).+$'
           message: 'Your branch name should be like feature/SOME-TICKET-NUMBER-some-description`
```