### PR TITLE
feat: Add docker image build and push

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+npm-debug.log
+*.pem
+.env
+coverage

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push latest
+        uses: docker/build-push-action@v2
+        if: github.ref == 'refs/heads/master'
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mergeable:latest
+
+      - name: Set version variable
+        id: version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+
+      - name: Build and push tag
+        uses: docker/build-push-action@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mergeable:${{ steps.version.outputs.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,7 @@ RUN npm ci --only=production
 
 COPY . .
 
-FROM gcr.io/distroless/nodejs:14
-
-COPY --from=build /app /app
-
-EXPOSE 3000
+ENV PORT=${PORT:-3000}
 USER 1000:1000
 
-CMD [ "/app/node_modules/probot/bin/probot.js", "run", "/app/index.js" ]
+CMD ./node_modules/probot/bin/probot.js run --port $PORT ./index.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 AS build
+FROM node:12.16.0
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:14 AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --only=production
+
+COPY . .
+
+FROM gcr.io/distroless/nodejs:14
+
+COPY --from=build /app /app
+
+EXPOSE 3000
+USER 1000:1000
+
+CMD [ "/app/node_modules/probot/bin/probot.js", "run", "/app/index.js" ]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,6 @@ CHANGELOG
 =====================================
 
 
-
 | December 18, 2020 : feat: Better logs for failures in PR home page without going to details `#446 <https://github.com/mergeability/mergeable/issues/446>`_
 | December 17, 2020 : fix: Members in Org listing pagination bug `#442 <https://github.com/mergeability/mergeable/issues/442>`_
 | December 17, 2020 : feat: Add docker image build and push `#427 <https://github.com/mergeability/mergeable/issues/427>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ CHANGELOG
 =====================================
 
 
+| December 17, 2020 : feat: Add docker image build and push `#427 <https://github.com/mergeability/mergeable/issues/427>`_
 | December 14, 2020 : feat: Add branch validator `#438 <https://github.com/mergeability/mergeable/issues/438>`_
 | December 11, 2020 : feat: Add env to control which configuration file to use `#429 <https://github.com/mergeability/mergeable/issues/429>`_
 | October 20, 2020 : feat: Add a config cache which can be enabled via MERGEABLE_ENABLE_CONFIG_CACHE env var `#407 <https://github.com/mergeability/mergeable/issues/407>`_


### PR DESCRIPTION
Fixes #427

This PR introduces a Docker image by adding a Dockerfile and an Actions pipeline to build and push to Docker Hub.

A Docker Hub account will be required and also is necessary to set repository secrets `DOCKERHUB_USERNAME` with the account name and `DOCKERHUB_PASSWORD` with the generated token.