### PR TITLE
feat: GitHub actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,33 @@
+name: Docker PR
+
+on:
+  pull_request:
+    types: ["*"]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_REPO }}:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: ${{ secrets.DOCKERHUB_PUSH }}
     name: Build and push Docker image
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   docker:
+    if: ${{ secrets.DOCKERHUB_PUSH }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,15 @@
-name: Docker PR
+name: Release
 
 on:
-  pull_request:
-    types: ["*"]
+  push:
+    branches:
+      - master
 
 jobs:
-  main:
+  docker:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,24 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build --if-present
+    - run: npm test
+      env:
+        CI: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,3 +22,14 @@ jobs:
     - run: npm run test-coverage
       env:
         CI: true
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: ./coverage/
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: codecov-mergeable
+        fail_ci_if_error: true
+        path_to_write_report: ./coverage/codecov_report.txt
+        verbose: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,6 +19,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm run build --if-present
-    - run: npm test
+    - run: npm run test-coverage
       env:
         CI: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,10 +25,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/
-        flags: unittests
-        env_vars: OS,PYTHON
         name: codecov-mergeable
         fail_ci_if_error: true
         path_to_write_report: ./coverage/codecov_report.txt

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ CHANGELOG
 =====================================
 
 
+| January 4, 2021 : feat: Github actions support rather than CircleCI `#450 <https://github.com/mergeability/mergeable/issues/450>`_
 | December 18, 2020 : feat: Better logs for failures in PR home page without going to details `#446 <https://github.com/mergeability/mergeable/issues/446>`_
 | December 17, 2020 : fix: Members in Org listing pagination bug `#442 <https://github.com/mergeability/mergeable/issues/442>`_
 | December 14, 2020 : feat: Add branch validator `#438 <https://github.com/mergeability/mergeable/issues/438>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@ CHANGELOG
 =====================================
 
 
-| January 4, 2021 : feat: Github actions support rather than CircleCI `#450 <https://github.com/mergeability/mergeable/issues/450>`_
+| January 4, 2021 : feat: GitHub actions `#450 <https://github.com/mergeability/mergeable/issues/450>`_
 | December 18, 2020 : feat: Better logs for failures in PR home page without going to details `#446 <https://github.com/mergeability/mergeable/issues/446>`_
 | December 17, 2020 : fix: Members in Org listing pagination bug `#442 <https://github.com/mergeability/mergeable/issues/442>`_
 | December 14, 2020 : feat: Add branch validator `#438 <https://github.com/mergeability/mergeable/issues/438>`_


### PR DESCRIPTION
Related issue: https://github.com/mergeability/mergeable/issues/450

---

This PR enables Github-Actions for PRs to test and upload coverage to codecov and release docker image after pushed to master.

For docker release to be worked;

You need to create 3 secrets;

- DOCKERHUB_PUSH - true/false to enable docker releasing
- DOCKERHUB_USERNAME - Docker hub username
- DOCKERHUB_TOKEN - Docker hub access token
- DOCKERHUB_REPO - Docker hub repo address (i.e. `mergeability/mergeable`)
