### PR TITLE
fix: Shift fix in team slug pagination

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ CHANGELOG
 =====================================
 
 
+| January 5, 2021 : fix: Shift fix in team slug pagination
 | December 18, 2020 : feat: Better logs for failures in PR home page without going to details `#446 <https://github.com/mergeability/mergeable/issues/446>`_
 | December 17, 2020 : fix: Members in Org listing pagination bug `#442 <https://github.com/mergeability/mergeable/issues/442>`_
 | December 14, 2020 : feat: Add branch validator `#438 <https://github.com/mergeability/mergeable/issues/438>`_

--- a/lib/validators/options_processor/teams.js
+++ b/lib/validators/options_processor/teams.js
@@ -72,7 +72,7 @@ const getTeamMembershipState = async (context, team, username) => {
   if (stringArray.length !== 2) {
     throw Error(`each team id needs to be given in 'org/team_slug'`)
   }
- if (stringArray[0].indexOf('@') === 0) stringArray[0] = stringArray[0].substring(1)
+  if (stringArray[0].indexOf('@') === 0) stringArray[0] = stringArray[0].substring(1)
 
   const org = stringArray[0]
   const teamSlug = stringArray[1]

--- a/lib/validators/options_processor/teams.js
+++ b/lib/validators/options_processor/teams.js
@@ -72,7 +72,7 @@ const getTeamMembershipState = async (context, team, username) => {
   if (stringArray.length !== 2) {
     throw Error(`each team id needs to be given in 'org/team_slug'`)
   }
-  if (stringArray[0].indexOf('@') === 0) stringArray.shift()
+ if (stringArray[0].indexOf('@') === 0) stringArray[0] = stringArray[0].substring(1)
 
   const org = stringArray[0]
   const teamSlug = stringArray[1]


### PR DESCRIPTION
I have to keep take the shift back to old way, beucase it causes some problem as below:

````
HttpError: Empty value for parameter 'team_slug': undefined
    at /app/node_modules/@octokit/rest/plugins/validate/validate.js:74:15
    at Array.forEach (<anonymous>)
    at /app/node_modules/@octokit/rest/plugins/validate/validate.js:42:12
    at Array.forEach (<anonymous>)
    at validate (/app/node_modules/@octokit/rest/plugins/validate/validate.js:15:23)
```