### PR TITLE
fix: Prevent add comma on last list element

### DIFF
--- a/__tests__/e2e/smoke.test.js
+++ b/__tests__/e2e/smoke.test.js
@@ -53,7 +53,7 @@ mergeable:
     let updateCheckOptions = {expectedBody: { name: 'Mergeable',
       status: 'completed',
       output:
-      { title: '1/1 Fail(s):  TITLE,  ',
+      { title: '1/1 Fail(s):  TITLE',
         summary:
             '### Status: FAIL\n\n        Here are some stats of the run:\n        1 validations were ran.\n        0 PASSED\n        1 FAILED\n      ',
         text:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@ CHANGELOG
 =====================================
 
 
+| January 8, 2021 : fix: Prevent add comma on last list element
 | January 5, 2021 : fix: Shift fix in team slug pagination
 | December 18, 2020 : feat: Better logs for failures in PR home page without going to details `#446 <https://github.com/mergeability/mergeable/issues/446>`_
 | December 17, 2020 : fix: Members in Org listing pagination bug `#442 <https://github.com/mergeability/mergeable/issues/442>`_

--- a/lib/configuration/lib/consts.js
+++ b/lib/configuration/lib/consts.js
@@ -15,7 +15,7 @@ module.exports = {
     state: 'completed',
     status: 'failure',
     payload: {
-      title: `{{failCount}}/{{validationCount}} Fail(s): {{#each failures}} {{toUpperCase name}}{{^-last}}, {{/-last}} {{/each}}`,
+      title: `{{failCount}}/{{validationCount}} Fail(s): {{#each failures}} {{toUpperCase name}}{{^@last}}, {{/@last}}{{/each}}`,
       summary: `### Status: {{toUpperCase validationStatus}}
 
         Here are some stats of the run:


### PR DESCRIPTION
This PR removes the last list element comma by properly using the `last` function.

So instead of this:
`2/2 Fail(s): HEADREF, DESCRIPTION,`
Will be this:
`2/2 Fail(s): HEADREF, DESCRIPTION`