### PR TITLE
chore: push to ghcr instead

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,44 +1,77 @@
-name: Release
+name: Docker
 
 on:
   push:
-    tags:
-      - '*'
+    # Publish `master` as Docker `latest` image.
     branches:
       - master
 
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: mergeable
+
 jobs:
-  build:
-    name: Build and push Docker image
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
 
-      - name: Build and push latest
-        uses: docker/build-push-action@v2
-        if: github.ref == 'refs/heads/master'
-        with:
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mergeable:latest
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
-      - name: Set version variable
-        id: version
-        if: startsWith(github.ref, 'refs/tags/')
-        run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+    steps:
+      - uses: actions/checkout@v2
 
-      - name: Build and push tag
-        uses: docker/build-push-action@v2
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mergeable:${{ steps.version.outputs.TAG }}
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into GitHub Container Registry
+      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
In #445 a workflow was set up to push image to docker.io, while nobody has set up a corresponding dockerhub token or password for it.
I think we can just push it to ghcr.io instead, which does not require any configuration, it just works!

Update: I tried myself and found this workflow also requires a github personal token that has permission to push. So it's not exactly no configuration.