### PR TITLE
chore: make proper use log.info on recently merged PRs

### DIFF
--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -39,11 +39,11 @@ const deleteOldComments = async (context, oldComments) => {
           log_type: logger.logTypes.DELETE_COMMENT_FAIL_ERROR,
           event_id: context.eventId,
           repo: context.payload.repository.full_name,
-          action_name: this.name,
+          action_name: 'comment',
           comment_id: comment.id
         }
-
-        this.log.info(JSON.stringify(errorLog))
+        const log = logger.create(`action/comment`)
+        log.info(JSON.stringify(errorLog))
       }
     }
   }

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -3,10 +3,10 @@ const populateTemplate = require('./handlebars/populateTemplate')
 const logger = require('../logger')
 const _ = require('lodash')
 
-const updateItemWithComment = async (context, issueNumber, body, leaveOldComment) => {
+const updateItemWithComment = async (context, issueNumber, body, leaveOldComment, actionObj) => {
   if (!leaveOldComment) {
     const oldComments = await fetchCommentsByMergeable(context, issueNumber)
-    await deleteOldComments(context, oldComments)
+    await deleteOldComments(context, oldComments, actionObj)
   }
   return createComment(context, issueNumber, body)
 }
@@ -26,7 +26,7 @@ const fetchCommentsByMergeable = async (context, issueNumber) => {
   return comments.data.filter(comment => comment.user.login.toLowerCase() === `${botName.toLowerCase()}[bot]`)
 }
 
-const deleteOldComments = async (context, oldComments) => {
+const deleteOldComments = async (context, oldComments, actionObj) => {
   for (let comment of oldComments) {
     try {
       await context.octokit.issues.deleteComment(
@@ -39,11 +39,11 @@ const deleteOldComments = async (context, oldComments) => {
           log_type: logger.logTypes.DELETE_COMMENT_FAIL_ERROR,
           event_id: context.eventId,
           repo: context.payload.repository.full_name,
-          action_name: 'comment',
+          action_name: actionObj.name,
           comment_id: comment.id
         }
-        const log = logger.create(`action/comment`)
-        log.info(JSON.stringify(errorLog))
+
+        actionObj.log.info(JSON.stringify(errorLog))
       }
     }
   }
@@ -92,7 +92,8 @@ class Comment extends Action {
           context,
           issue.number,
           populateTemplate(settings.payload.body, results, issue),
-          settings.leave_old_comment
+          settings.leave_old_comment,
+          this
         )
       })
     )

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -23,10 +23,18 @@ const checkIfMerged = async (context, prNumber) => {
   return status
 }
 
-const mergePR = async (context, prNumber, mergeMethod) => {
+const mergePR = async (context, prNumber, mergeMethod, actionObj) => {
   const isMerged = await checkIfMerged(context, prNumber)
   if (!isMerged) {
     const pullRequest = await context.octokit.pulls.get(context.repo({ pull_number: prNumber }))
+    const errorLog = {
+      log_type: logger.logTypes.MERGE_FAIL_ERROR,
+      eventId: context.eventId,
+      repo: context.payload.repository.full_name,
+      action_name: actionObj.name
+    }
+
+    actionObj.info(JSON.stringify(errorLog))
     if (pullRequest.data.mergeable_state !== 'blocked' && pullRequest.data.state === 'open') {
       try {
         await context.octokit.pulls.merge(context.repo({ pull_number: prNumber, merge_method: mergeMethod }))
@@ -42,11 +50,10 @@ const mergePR = async (context, prNumber, mergeMethod) => {
             log_type: logger.logTypes.MERGE_FAIL_ERROR,
             eventId: context.eventId,
             repo: context.payload.repository.full_name,
-            action_name: 'merge'
+            action_name: actionObj.name
           }
 
-          const log = logger.create(`action/merge`)
-          log.info(JSON.stringify(errorLog))
+          actionObj.info(JSON.stringify(errorLog))
         } else {
           throw err
         }
@@ -98,7 +105,8 @@ class Merge extends Action {
         mergePR(
           context,
           issue.number,
-          mergeMethod
+          mergeMethod,
+          this
         )
       })
     )

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -42,10 +42,11 @@ const mergePR = async (context, prNumber, mergeMethod) => {
             log_type: logger.logTypes.MERGE_FAIL_ERROR,
             eventId: context.eventId,
             repo: context.payload.repository.full_name,
-            action_name: this.name
+            action_name: 'merge'
           }
 
-          this.log.info(JSON.stringify(errorLog))
+          const log = logger.create(`action/merge`)
+          log.info(JSON.stringify(errorLog))
         } else {
           throw err
         }

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -27,14 +27,6 @@ const mergePR = async (context, prNumber, mergeMethod, actionObj) => {
   const isMerged = await checkIfMerged(context, prNumber)
   if (!isMerged) {
     const pullRequest = await context.octokit.pulls.get(context.repo({ pull_number: prNumber }))
-    const errorLog = {
-      log_type: logger.logTypes.MERGE_FAIL_ERROR,
-      eventId: context.eventId,
-      repo: context.payload.repository.full_name,
-      action_name: actionObj.name
-    }
-
-    actionObj.info(JSON.stringify(errorLog))
     if (pullRequest.data.mergeable_state !== 'blocked' && pullRequest.data.state === 'open') {
       try {
         await context.octokit.pulls.merge(context.repo({ pull_number: prNumber, merge_method: mergeMethod }))


### PR DESCRIPTION
fix the log usage in #484 #479

Context : the functions calling `this` is outside of the class