### PR TITLE
chore: update testing action node version to align with package.json

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on:
     branches: ['**']
   pull_request:
     branches: ['**']
-    types: [synchronize, opened]
+    types: [synchronize]
 
 jobs:
   build:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['master']
+    branches: ['**']
   pull_request:
     branches: ['**']
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,9 +3,7 @@ name: CI
 on:
   push:
     branches: ['**']
-  pull_request:
-    branches: ['**']
-
+  
 jobs:
   build:
     name: Tests and Code Coverage

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['master']
+    branches: ['**']
   pull_request:
     branches: ['**']
     types: [synchronize, opened]
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.15.4]
 
     steps:
     - uses: actions/checkout@v2
@@ -27,11 +27,3 @@ jobs:
     - run: npm run test-coverage
       env:
         CI: true
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        directory: ./coverage/
-        name: codecov-mergeable
-        fail_ci_if_error: true
-        path_to_write_report: ./coverage/codecov_report.txt
-        verbose: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,10 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: ['master']
   pull_request:
     branches: ['**']
-    types: [synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
## Changes
- chore: update testing workflow node version to align with package.json
- fix: the npm command test-coverage invokes an upload to codecov. Remove redundant GH action to upload which is a dup.
- fix: to invoke CI on push in a PR branch