### PR TITLE
feat: add `name` sub option to `repository` filter

### DIFF
--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -16,6 +16,7 @@ module.exports = {
         sha: 'sha1',
         action: 'opened',
         repository: {
+          name: (options.repoName) ? options.repoName : 'repoName',
           full_name: 'name',
           owner: {
             login: 'owner'

--- a/__tests__/unit/filters/repository.test.js
+++ b/__tests__/unit/filters/repository.test.js
@@ -129,7 +129,71 @@ test('fail to must exclude topic', async () => {
   expect(filter.status).toBe('fail')
 })
 
-const mockContext = (repoPrivate, repoTopics) => {
-  const context = Helper.mockContext({ repoPrivate: repoPrivate, repoTopics: repoTopics })
+test('fail to must include name', async () => {
+  const repo = new Repository()
+
+  const settings = {
+    do: 'repository',
+    name: {
+      must_include: {
+        regex: 'test-repo-2'
+      }
+    }
+  }
+
+  const filter = await repo.processFilter(mockContext(true, ['mytopic'], 'test-repo'), settings)
+  expect(filter.status).toBe('fail')
+})
+
+test('must_include name passes', async () => {
+  const repo = new Repository()
+
+  const settings = {
+    do: 'repository',
+    name: {
+      must_include: {
+        regex: 'test-repo-2'
+      }
+    }
+  }
+
+  const filter = await repo.processFilter(mockContext(true, ['mytopic'], 'test-repo-2'), settings)
+  expect(filter.status).toBe('pass')
+})
+
+test('fail to must exclude name', async () => {
+  const repo = new Repository()
+
+  const settings = {
+    do: 'repository',
+    name: {
+      must_exclude: {
+        regex: 'test-repo'
+      }
+    }
+  }
+
+  const filter = await repo.processFilter(mockContext(true, ['mytopic'], 'test-repo'), settings)
+  expect(filter.status).toBe('fail')
+})
+
+test('must_exclude name passes', async () => {
+  const repo = new Repository()
+
+  const settings = {
+    do: 'repository',
+    name: {
+      must_exclude: {
+        regex: 'test-repo'
+      }
+    }
+  }
+
+  const filter = await repo.processFilter(mockContext(true, ['mytopic'], 'not-desired-repo-2'), settings)
+  expect(filter.status).toBe('pass')
+})
+
+const mockContext = (repoPrivate, repoTopics, repoName) => {
+  const context = Helper.mockContext({ repoPrivate: repoPrivate, repoTopics: repoTopics, repoName: repoName })
   return context
 }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| February 21, 2021 : feat: `name` sub-option for `repository` filter
 | February 12, 2021 : feat: Implemented redis as a dependency to the helm-chart
 | February 10, 2021 : feat: global cache manager `#502 <https://github.com/mergeability/mergeable/pull/502>`_
 | February 10, 2021 : feat: Implement and/or filters support `#496 <https://github.com/mergeability/mergeable/pull/504>`_

--- a/docs/filters/repository.rst
+++ b/docs/filters/repository.rst
@@ -5,6 +5,11 @@ Repository
 
       - do: repository
         visibility: 'public' # Can be public or private
+        name:
+          must_include:
+            regex: 'my-repo-name'
+          must_exclude:
+            regex: 'other-repo-name'
         topics:
           must_include:
             regex: 'my-topic'

--- a/lib/filters/options_processor/name.js
+++ b/lib/filters/options_processor/name.js
@@ -1,0 +1,11 @@
+const Options = require('./options')
+
+class Name {
+  static async process (context, filter, settings) {
+    let input = context.payload.repository.name
+    let result = await Options.process(context, filter, input, settings.name)
+    return { input: {name: input}, result }
+  }
+}
+
+module.exports = Name

--- a/lib/filters/repository.js
+++ b/lib/filters/repository.js
@@ -1,5 +1,6 @@
 const Topics = require('./options_processor/topics')
 const Visibility = require('./options_processor/visibility')
+const Name = require('./options_processor/name')
 const { Filter } = require('./filter')
 const consolidateResult = require('./options_processor/options/lib/consolidateResults')
 const constructOutput = require('./options_processor/options/lib/constructOutput')
@@ -14,6 +15,18 @@ class Repository extends Filter {
     this.supportedSettings = {
       visibility: 'string',
       topics: {
+        must_include: {
+          regex: 'string',
+          regex_flag: 'string',
+          message: 'string'
+        },
+        must_exclude: {
+          regex: 'string',
+          regex_flag: 'string',
+          message: 'string'
+        }
+      },
+      name: {
         must_include: {
           regex: 'string',
           regex_flag: 'string',
@@ -46,6 +59,10 @@ class Repository extends Filter {
       output.push(constructOutput(filter, processor.input, { visibility: settings.visibility }, processor.result))
     }
 
+    if (settings.name) {
+      let processor = await Name.process(context, filter, settings)
+      output.push(constructOutput(filter, processor.input, { name: settings.name }, processor.result))
+    }
     return consolidateResult(output, filter)
   }
 }


### PR DESCRIPTION
sample config
```
- do: repository
        name:
          must_include:
            regex: 'my-repo-name'
          must_exclude:
            regex: 'other-repo-name'
```

https://github.com/mergeability/mergeable/issues/509#issuecomment-782806518