### PR TITLE
WIP: test error logger/catcher layer

### DIFF
--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -1,6 +1,8 @@
 const yaml = require('js-yaml')
 const _ = require('lodash')
 const CacheManager = require('../cache/cache')
+const GithubAPI = require('../github/api')
+const logger = require('../logger')
 
 // Setup the cache manager
 const cacheManager = new CacheManager()
@@ -130,12 +132,7 @@ class Configuration {
       // As a result here we only load the config if the PR is from the same repo
       // as the base
       if (payload.head.repo.full_name === payload.base.repo.full_name) {
-        let result = await context.octokit.paginate(
-          context.octokit.pulls.listFiles.endpoint.merge(
-            context.repo({ pull_number: context.payload.pull_request.number })
-          ),
-          res => res.data
-        )
+        let result = await GithubAPI.listFiles(context, context.repo({ pull_number: context.payload.pull_request.number }), logger.create('configuration'))
 
         // get modified file list
         let modifiedFiles = result

--- a/lib/github/api.js
+++ b/lib/github/api.js
@@ -1,0 +1,42 @@
+const logger = require('../logger')
+
+const createLog = (err, context, option) => {
+  return Object.assign({
+    logType: logger.logTypes.UNKNOWN_GITHUB_API_ERROR,
+    eventId: context.eventId,
+    errors: err.toString(),
+    repo: context.payload.repository.full_name,
+    event: `${context.eventName}.${context.payload.action}`
+  }, option)
+}
+
+const checkKnownError = (err, log, ErrorLog) => {
+  switch (err.status) {
+    case '500':
+      ErrorLog.logType = logger.logTypes.GITHUB_SERVER_ERROR
+      log.info(ErrorLog)
+      break
+    case '404':
+      ErrorLog.logType = logger.logTypes.HTTP_NOT_FOUND_ERROR
+      log.info(ErrorLog)
+      break
+    default:
+      log.error(ErrorLog)
+      throw err // bubble it up so that it'll create an unknown error check
+  }
+}
+
+class GithubAPI {
+  static async listFiles (context, callParams, log) {
+    return context.octokit.paginate(
+      context.octokit.pulls.listFiles.endpoint.merge(
+        callParams
+      ),
+      res => res.data
+    ).catch((err) => {
+      checkKnownError(err, context, createLog(err, context, {callFn: 'pulls.listFiles'}))
+    })
+  }
+}
+
+module.exports = GithubAPI

--- a/lib/utils/logTypes.js
+++ b/lib/utils/logTypes.js
@@ -14,5 +14,9 @@ module.exports = {
   MERGE_FAIL_ERROR: 'merge_fail_error',
   DELETE_COMMENT_FAIL_ERROR: 'delete_comment_fail_error',
   REQUEST_REVIEW_FAIL_ERROR: 'request_review_fail_error',
-  ISSUE_GET_FAIL_ERROR: 'issue_get_fail_error'
+  ISSUE_GET_FAIL_ERROR: 'issue_get_fail_error',
+  UNKNOWN_GITHUB_API_ERROR: 'unknown_github_api_error',
+  GITHUB_SERVER_ERROR: 'github_server_error',
+  HTTP_NOT_FOUND_ERROR: 'http_not_found_error',
+  COMMIT_NOT_FOUND_ERROR: 'commit_not_found_error'
 }

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -43,12 +43,7 @@ class Changeset extends Validator {
 
   async validate (context, validationSettings) {
     // fetch the file list
-    let result = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    let result = await this.github.listFiles(context, context.repo({ pull_number: this.getPayload(context).number }), this.log)
 
     let changedFiles = result.map(file => file.filename)
 

--- a/lib/validators/contents.js
+++ b/lib/validators/contents.js
@@ -51,12 +51,7 @@ class Contents extends Validator {
       delete parseOption.files
     }
 
-    let result = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    let result = await this.github.listFiles(context, context.repo({ pull_number: this.getPayload(context).number }), this.log)
     let changedFiles = result
       .filter(file => !matchesIgnoredPatterns(file.filename, patternsToIgnore))
       .filter(file => file.status === 'modified' || file.status === 'added')

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -31,12 +31,7 @@ class Dependent extends Validator {
     const DEFUALT_SUCCESS_MESSAGE = 'All the Dependents files are present!'
 
     // fetch the file list
-    let result = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    let result = await this.github.listFiles(context, context.repo({ pull_number: this.getPayload(context).number }), this.log)
 
     let modifiedFiles = result
       .filter(file => file.status === 'modified' || file.status === 'added')

--- a/lib/validators/options_processor/owners.js
+++ b/lib/validators/options_processor/owners.js
@@ -1,6 +1,8 @@
 const gitPattern = require('./gitPattern')
 const Teams = require('./teams')
 const _ = require('lodash')
+const GithubAPI = require('../../github/api')
+const logger = require('../../logger')
 
 class Owner {
   static async process (payload, context) {
@@ -74,12 +76,7 @@ const retrieveCODEOWNER = async (context, pullNumber) => {
 
   if (['pull_request', 'pull_request_review'].includes(context.eventName)) {
     // get modified file list
-    let result = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: pullNumber })
-      ),
-      res => res.data
-    )
+    let result = await GithubAPI.listFiles(context, context.repo({ pull_number: context.payload.pull_request.number }), logger.create('owners'))
 
     let modifiedFiles = result
       .filter(file => ['modified', 'added'].includes(file.status))

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -64,12 +64,7 @@ class Size extends Validator {
 
     const patternsToInclude = validationSettings.match || ['**']
     const patternsToIgnore = validationSettings.ignore || []
-    const listFilesResult = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    const listFilesResult = await this.github.listFiles(context, context.repo({ pull_number: this.getPayload(context).number }), this.log)
 
     let modifiedFiles
     if (validationSettings.lines && validationSettings.lines.ignore_comments) {

--- a/lib/validators/validator.js
+++ b/lib/validators/validator.js
@@ -5,6 +5,7 @@ const logger = require('../logger')
 const UnSupportedSettingError = require('../errors/unSupportedSettingError')
 const constructErrorOutput = require('./options_processor/options/lib/constructErrorOutput')
 const consolidateResult = require('./options_processor/options/lib/consolidateResults')
+const GithubAPI = require('../github/api')
 
 const DEFAULT_SUPPORTED_OPTIONS = [
   'and',
@@ -27,6 +28,7 @@ class Validator extends EventAware {
     this.name = name
     this.log = logger.create(`validator/${name}`)
     this.supportedOptions = DEFAULT_SUPPORTED_OPTIONS
+    this.github = GithubAPI
   }
 
   async validate () {


### PR DESCRIPTION
Currently, we have a catch all errors for `validators, filters and actions` but it can be very hard to debug since it's hard to pin point which `validator, filter or action` threw the error. 
This is an attempt to address it by catching all the github api call error and logging them.
I also noticed that there are multiple calls to the same end point from different location, this could help consolidate those

NOTE: this is just a sample for discussion purposes, not the complete implementation of the feature