### PR TITLE
refactor: githubAPI abstraction layer

### DIFF
--- a/__tests__/unit/github/api.test.js
+++ b/__tests__/unit/github/api.test.js
@@ -1,0 +1,24 @@
+const GithubAPI = require('../../../lib/github/api')
+const Helper = require('../../../__fixtures__/unit/helper')
+
+describe('listFiles', () => {
+  test('return correct data if no error', async () => {
+    const res = await GithubAPI.listFiles(Helper.mockContext({files: ['abc.js', 'def.js']}))
+
+    expect(res.length).toEqual(2)
+    expect(res[0]).toEqual({filename: 'abc.js', additions: 0, deletions: 0, changes: 0, status: 'modified'})
+  })
+
+  test('that error are re-thrown', async () => {
+    const context = Helper.mockContext()
+    context.octokit.pulls.listFiles.endpoint.merge = jest.fn().mockRejectedValue({status: 402})
+
+    try {
+      await GithubAPI.listFiles(context)
+      // Fail test if above expression doesn't throw anything.
+      expect(true).toBe(false)
+    } catch (e) {
+      expect(e.status).toBe(402)
+    }
+  })
+})

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -1,6 +1,7 @@
 const yaml = require('js-yaml')
 const _ = require('lodash')
 const CacheManager = require('../cache/cache')
+const GithubAPI = require('../github/api')
 
 // Setup the cache manager
 const cacheManager = new CacheManager()
@@ -130,12 +131,7 @@ class Configuration {
       // As a result here we only load the config if the PR is from the same repo
       // as the base
       if (payload.head.repo.full_name === payload.base.repo.full_name) {
-        let result = await context.octokit.paginate(
-          context.octokit.pulls.listFiles.endpoint.merge(
-            context.repo({ pull_number: context.payload.pull_request.number })
-          ),
-          res => res.data
-        )
+        let result = await GithubAPI.listFiles(context, context.repo({ pull_number: context.payload.pull_request.number }))
 
         // get modified file list
         let modifiedFiles = result

--- a/lib/github/api.js
+++ b/lib/github/api.js
@@ -34,7 +34,7 @@ const debugLog = (context, callFn) => {
 }
 
 class GithubAPI {
-  static async listFiles (context, callParams, log) {
+  static async listFiles (context, callParams) {
     const callFn = 'pulls.listFiles'
     debugLog(context, callFn)
 

--- a/lib/github/api.js
+++ b/lib/github/api.js
@@ -1,0 +1,52 @@
+const logger = require('../logger')
+
+const createLog = (context, option) => {
+  return Object.assign({
+    logType: logger.logTypes.UNKNOWN_GITHUB_API_ERROR,
+    eventId: context.eventId,
+    repo: context.payload.repository.full_name,
+    event: `${context.eventName}.${context.payload.action}`
+  }, option)
+}
+
+const checkCommonError = (err, context, callFn) => {
+  const log = logger.create(`GithubAPI/${callFn}`)
+
+  const errorLog = createLog(context, {callFn: callFn, errors: err.toString()})
+
+  switch (err.status) {
+    case 500:
+      errorLog.logType = logger.logTypes.GITHUB_SERVER_ERROR
+      break
+    case 404:
+      errorLog.logType = logger.logTypes.HTTP_NOT_FOUND_ERROR
+      break
+    default:
+  }
+  log.error(errorLog)
+  throw err // bubble up the error so that the flow will break, unless it is need
+}
+
+const debugLog = (context, callFn) => {
+  const log = logger.create(`GithubAPI/${callFn}`)
+  const debugLog = createLog(context, { callFn, logType: logger.logTypes.GITHUB_API_DEBUG })
+  log.debug(JSON.stringify(debugLog))
+}
+
+class GithubAPI {
+  static async listFiles (context, callParams, log) {
+    const callFn = 'pulls.listFiles'
+    debugLog(context, callFn)
+
+    return context.octokit.paginate(
+      context.octokit.pulls.listFiles.endpoint.merge(
+        callParams
+      ),
+      res => res.data
+    ).catch((err) => {
+      return checkCommonError(err, context, callFn)
+    })
+  }
+}
+
+module.exports = GithubAPI

--- a/lib/utils/logTypes.js
+++ b/lib/utils/logTypes.js
@@ -14,5 +14,9 @@ module.exports = {
   MERGE_FAIL_ERROR: 'merge_fail_error',
   DELETE_COMMENT_FAIL_ERROR: 'delete_comment_fail_error',
   REQUEST_REVIEW_FAIL_ERROR: 'request_review_fail_error',
-  ISSUE_GET_FAIL_ERROR: 'issue_get_fail_error'
+  ISSUE_GET_FAIL_ERROR: 'issue_get_fail_error',
+  UNKNOWN_GITHUB_API_ERROR: 'unknown_github_api_error',
+  GITHUB_SERVER_ERROR: 'github_server_error',
+  HTTP_NOT_FOUND_ERROR: 'http_not_found_error',
+  GITHUB_API_DEBUG: 'github_api_debug'
 }

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -43,12 +43,7 @@ class Changeset extends Validator {
 
   async validate (context, validationSettings) {
     // fetch the file list
-    let result = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    let result = await this.githubAPI.listFiles(context, context.repo({ pull_number: this.getPayload(context).number }))
 
     let changedFiles = result.map(file => file.filename)
 

--- a/lib/validators/contents.js
+++ b/lib/validators/contents.js
@@ -51,12 +51,7 @@ class Contents extends Validator {
       delete parseOption.files
     }
 
-    let result = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    let result = await this.githubAPI.listFiles(context, context.repo({ pull_number: this.getPayload(context).number }))
     let changedFiles = result
       .filter(file => !matchesIgnoredPatterns(file.filename, patternsToIgnore))
       .filter(file => file.status === 'modified' || file.status === 'added')

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -31,12 +31,7 @@ class Dependent extends Validator {
     const DEFUALT_SUCCESS_MESSAGE = 'All the Dependents files are present!'
 
     // fetch the file list
-    let result = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    let result = await this.githubAPI.listFiles(context, context.repo({ pull_number: this.getPayload(context).number }))
 
     let modifiedFiles = result
       .filter(file => file.status === 'modified' || file.status === 'added')

--- a/lib/validators/options_processor/owners.js
+++ b/lib/validators/options_processor/owners.js
@@ -1,6 +1,7 @@
 const gitPattern = require('./gitPattern')
 const Teams = require('./teams')
 const _ = require('lodash')
+const GithubAPI = require('../../github/api')
 
 class Owner {
   static async process (payload, context) {
@@ -74,12 +75,7 @@ const retrieveCODEOWNER = async (context, pullNumber) => {
 
   if (['pull_request', 'pull_request_review'].includes(context.eventName)) {
     // get modified file list
-    let result = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: pullNumber })
-      ),
-      res => res.data
-    )
+    let result = await GithubAPI.listFiles(context, context.repo({ pull_number: context.payload.pull_request.number }))
 
     let modifiedFiles = result
       .filter(file => ['modified', 'added'].includes(file.status))

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -64,12 +64,7 @@ class Size extends Validator {
 
     const patternsToInclude = validationSettings.match || ['**']
     const patternsToIgnore = validationSettings.ignore || []
-    const listFilesResult = await context.octokit.paginate(
-      context.octokit.pulls.listFiles.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    const listFilesResult = await this.githubAPI.listFiles(context, context.repo({ pull_number: this.getPayload(context).number }))
 
     let modifiedFiles
     if (validationSettings.lines && validationSettings.lines.ignore_comments) {

--- a/lib/validators/validator.js
+++ b/lib/validators/validator.js
@@ -5,6 +5,7 @@ const logger = require('../logger')
 const UnSupportedSettingError = require('../errors/unSupportedSettingError')
 const constructErrorOutput = require('./options_processor/options/lib/constructErrorOutput')
 const consolidateResult = require('./options_processor/options/lib/consolidateResults')
+const GithubAPI = require('../github/api')
 
 const DEFAULT_SUPPORTED_OPTIONS = [
   'and',
@@ -27,6 +28,7 @@ class Validator extends EventAware {
     this.name = name
     this.log = logger.create(`validator/${name}`)
     this.supportedOptions = DEFAULT_SUPPORTED_OPTIONS
+    this.githubAPI = GithubAPI
   }
 
   async validate () {


### PR DESCRIPTION
Refactor github api calls into an abstraction layer for two purposes:
- reusablility
- to catch and log errors 

Note: this PR only include one particular github API call, in order to keep the PR small. other github calls will be refactor in subsequent PRs