### PR TITLE
feat: Add rate limit related metrics/endpoint

### DIFF
--- a/__tests__/e2e/smoke.test.js
+++ b/__tests__/e2e/smoke.test.js
@@ -2,6 +2,7 @@ const nock = require('nock')
 // Requiring our app implementation
 const mergeable = require('../..')
 const { Probot, ProbotOctokit } = require('probot')
+const express = require('express')
 
 const MockHelper = require('../../__fixtures__/e2e/helper')
 
@@ -21,7 +22,7 @@ describe('smoke tests', () => {
         throttle: { enabled: false }
       })
     })
-    mergeable(probot)
+    mergeable(probot, { getRouter: () => { return express() } })
   })
 
   test('that mergeable run properly for an PR', async () => {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| March 25, 2021 : feat: Add rate limit related metrics/endpoint `#526 <https://github.com/mergeability/mergeable/pull/526>`_
 | February 25, 2021 : feat: add feature to limit approval to a list of users `#509 <https://github.com/mergeability/mergeable/issues/509>`_
 | February 25, 2021 : fix: minor bugs `#508 <https://github.com/mergeability/mergeable/pull/508>`_
 | February 25, 2021 : fix: Correct use of cache env

--- a/index.js
+++ b/index.js
@@ -1,7 +1,21 @@
 const { Mergeable } = require('./lib/mergeable')
 const logger = require('./lib/logger')
+const githubRateLimitEndpoint = require('./lib/utils/githubRateLimitEndpoint')
+const prometheusMiddleware = require('express-prometheus-middleware')
 
-module.exports = (robot) => {
+module.exports = (robot, { getRouter }) => {
+  const router = getRouter()
+
+  if (process.env.ENABLE_GITHUB_RATELIMIT_ENDPOINT === 'true') {
+    // endpoint to fetch github given installation rate limit
+    router.get('/github-ratelimit/:installationId', githubRateLimitEndpoint(robot))
+  }
+
+  if (process.env.ENABLE_METRICS_ENDPOINT === 'true') {
+    // expose prometheus metrics
+    router.use(prometheusMiddleware())
+  }
+
   logger.init(robot.log)
   let mergeable = new Mergeable(process.env.NODE_ENV)
   mergeable.start(robot)

--- a/lib/mergeable.js
+++ b/lib/mergeable.js
@@ -3,6 +3,7 @@ const flexExecutor = require('./flex/flex')
 const Context = require('./context')
 const logger = require('./logger')
 const _ = require('lodash')
+const { GithubRateLimitRemainingTotal, GithubRateLimitLimitTotal } = require('./stats/githubPrometheusStats')
 
 require('colors')
 
@@ -50,6 +51,18 @@ function logEventReceived (context) {
   log.info(JSON.stringify(eventReceivedLog))
 }
 
+function statEventReceived (context) {
+  context.octokit.hook.after('request', async (response) => {
+    GithubRateLimitRemainingTotal.labels({
+      installationId: context.payload.installation.id
+    }).set(Number(response.headers['x-ratelimit-remaining']))
+
+    GithubRateLimitLimitTotal.labels({
+      installationId: context.payload.installation.id
+    }).set(Number(response.headers['x-ratelimit-limit']))
+  })
+}
+
 class Mergeable {
   constructor (mode) {
     this.mode = mode
@@ -84,6 +97,7 @@ class Mergeable {
     robot.on('*', async pContext => {
       let context = new Context(pContext)
       logEventReceived(context)
+      statEventReceived(context)
 
       await flexExecutor(context)
     })

--- a/lib/stats/githubPrometheusStats.js
+++ b/lib/stats/githubPrometheusStats.js
@@ -1,0 +1,14 @@
+const Prometheus = require('prom-client')
+
+module.exports = {
+  GithubRateLimitRemainingTotal: new Prometheus.Gauge({
+    name: 'github_ratelimit_remaining_total',
+    help: 'The total amount of Rate Limit requests remaining',
+    labelNames: ['installationId']
+  }),
+  GithubRateLimitLimitTotal: new Prometheus.Gauge({
+    name: 'github_ratelimit_limit_total',
+    help: 'The total amount of Rate Limit requests limit',
+    labelNames: ['installationId']
+  })
+}

--- a/lib/utils/githubRateLimitEndpoint.js
+++ b/lib/utils/githubRateLimitEndpoint.js
@@ -1,0 +1,23 @@
+module.exports = (probot) => {
+  return async (req, res) => {
+    let octokit
+
+    if (req.params['installationId'] === '') {
+      res.json('missing parameter `installationId`')
+      return
+    }
+
+    try {
+      octokit = await probot.auth(req.params['installationId'])
+    } catch (err) {
+      res.json('invalid parameter `installationId`')
+      return
+    }
+
+    octokit.rateLimit.get().then(result => {
+      res.json(result.data.resources.core)
+    }).catch(err => {
+      res.json(`installation error: ${err.message}`)
+    })
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,6 +1580,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3363,6 +3368,16 @@
         }
       }
     },
+    "express-prometheus-middleware": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/express-prometheus-middleware/-/express-prometheus-middleware-1.1.0.tgz",
+      "integrity": "sha512-HqqgN7wGrmMWWxFo2Rcc4hQJYKrImqjLy2FJ/5H1UlO4Nh+gF/k/jXqsZqpvo+z5L7N0a0RjsDoX1gcA7fFmcA==",
+      "requires": {
+        "prometheus-gc-stats": "^0.6.2",
+        "response-time": "^2.3.2",
+        "url-value-parser": "^2.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3721,6 +3736,487 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gc-stats": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.4.0.tgz",
+      "integrity": "sha512-4FcCj9e8j8rCjvLkqRpGZBLgTC/xr9XEf5By3x77cDucWWB3pJK6FEwXZCTCbb4z8xdaOoi4owBNrvn3ciDdxA==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.13.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "optional": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "optional": true
+        }
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.1",
@@ -5612,7 +6108,6 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -5915,8 +6410,7 @@
     "on-headers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "dev": true
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
@@ -5934,6 +6428,12 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "optional": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
+      "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
+      "optional": true
     },
     "optionator": {
       "version": "0.8.3",
@@ -6547,6 +7047,24 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
+    "prometheus-gc-stats": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.3.tgz",
+      "integrity": "sha512-vCX+HZ1jZHkha25r5dAcRSNjue+K3Hn0B33EcZl7y3hgp3o1YsQ4Y3x7oJWKvDdbelFIL0McsXGmRg3zBrmq+g==",
+      "optional": true,
+      "requires": {
+        "gc-stats": "^1.4.0",
+        "optional": "^0.1.3"
+      }
+    },
     "prompts": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -6923,6 +7441,15 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "response-time": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
+      "requires": {
+        "depd": "~1.1.0",
+        "on-headers": "~1.0.1"
+      }
     },
     "responselike": {
       "version": "1.0.2",
@@ -7732,6 +8259,14 @@
         }
       }
     },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
+    },
     "term-size": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
@@ -8185,6 +8720,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "url-value-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.1.tgz",
+      "integrity": "sha512-bexECeREBIueboLGM3Y1WaAzQkIn+Tca/Xjmjmfd0S/hFHSCEoFkNh0/D0l9G4K74MkEP/lLFRlYnxX3d68Qgw=="
     },
     "urlgrey": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cache-manager": "^3.4.0",
     "cache-manager-ioredis": "^2.1.0",
     "colors": "^1.3.2",
+    "express-prometheus-middleware": "^1.1.0",
     "handlebars": "^4.7.6",
     "jira-client": "^6.21.1",
     "js-yaml": "^3.14.0",
@@ -28,7 +29,8 @@
     "moment-timezone": "^0.5.31",
     "node-fetch": "^2.6.1",
     "p-iteration": "^1.1.8",
-    "probot": "11.0.1"
+    "probot": "11.0.1",
+    "prom-client": "^13.1.0"
   },
   "devDependencies": {
     "codecov": "^3.7.2",


### PR DESCRIPTION
In order to better monitor mergeable, this PR adds two metrics-related endpoints that allow monitoring GitHub rate limiting.
Both endpoints are disabled by default, and can be enabled by setting their specific env to `true`.

## Metrics endpoint (`ENABLE_METRICS_ENDPOINT` env)
`GET /metrics`
```
# HELP github_ratelimit_remaining_total The total amount of Rate Limit requests remaining
# TYPE github_ratelimit_remaining_total gauge
github_ratelimit_remaining_total{installationId="13882267"} 4972

# HELP github_ratelimit_limit_total The total amount of Rate Limit requests limit
# TYPE github_ratelimit_limit_total gauge
github_ratelimit_limit_total{installationId="13882267"} 5000
```

## GitHub Rate Limit endpoint (`ENABLE_GITHUB_RATELIMIT_ENDPOINT` env)
`GET /github-ratelimit/:installationId`
```json
{"limit":5000,"used":36,"remaining":4964,"reset":1616674979}
```