### PR TITLE
feat: add chart support to prometheus servicemonitor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
 
+| March 31, 2021 : feat: add chart support to prometheus servicemonitor `#535 <https://github.com/mergeability/mergeable/pull/535>`_
 | March 30, 2021 : fix: codeowners team
 | March 25, 2021 : feat: Add rate limit related metrics/endpoint `#526 <https://github.com/mergeability/mergeable/pull/526>`_
 | February 25, 2021 : feat: add feature to limit approval to a list of users `#509 <https://github.com/mergeability/mergeable/issues/509>`_

--- a/helm/mergeable/templates/prometheus-servicemonitor.yaml
+++ b/helm/mergeable/templates/prometheus-servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.prometheus.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "mergeable.labels" $ | nindent 4 }}
+    prometheus: kube-prometheus
+  name: {{ include "mergeable.fullname" . }}
+spec:
+  endpoints:
+  - interval: {{ .Values.prometheus.service.metricInterval | default "30s" }}
+    path: {{ .Values.prometheus.service.metricPath | default "/metrics" }}
+    port: {{ .Values.prometheus.service.metricPortName | default "http" }}
+  jobLabel: {{ include "mergeable.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - "{{ $.Release.Namespace }}"
+  selector:
+    matchLabels:
+      app: {{ include "mergeable.fullname" . }}
+  sampleLimit: {{ .Values.prometheus.service.sampleLimit | default 5000}}
+{{- end }}

--- a/helm/mergeable/templates/service.yaml
+++ b/helm/mergeable/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "mergeable.fullname" . }}
   labels:
     {{- include "mergeable.labels" . | nindent 4 }}
+    app: {{ include "mergeable.fullname" . }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -87,6 +87,11 @@ affinity: {}
 
 prometheus:
   enabled: false
+  service: {}
+    # metricInterval: 30s
+    # metricPath: /metrics
+    # metricPortName: http
+    # sampleLimit: 5000
   rules: {}
     # - name: mergeable
     #   rules:


### PR DESCRIPTION
With this PR, helm chart will deploy a `ServiceMonitor` resource capable of monitoring mergeable metrics.