### PR TITLE
docs: update supported events for merge action

### DIFF
--- a/docs/actions/merge.rst
+++ b/docs/actions/merge.rst
@@ -9,4 +9,4 @@ Merge
 Supported Events:
 ::
 
-    'pull_request.*'
+    'pull_request.*', 'pull_request_review.*', 'status.*', 'check_suite.*'


### PR DESCRIPTION
As I'm reading the documentation, I noticed that the support events in code do not match in the documentation (https://github.com/mergeability/mergeable/blob/master/lib/actions/merge.js#L20:L24).