### PR TITLE
feat: Add `ignore_drafts` option to ignore drafts in stale validator

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
-| July 12, 2921 : feat: Filter specific status of files in changeset `#550 <https://github.com/mergeability/mergeable/issues/550>`_
+| July 19, 2021 : feat: Add ignore_drafts option to ignore drafts in stale validator `#565 <https://github.com/mergeability/mergeable/issues/565>`_
+| July 12, 2021 : feat: Filter specific status of files in changeset `#550 <https://github.com/mergeability/mergeable/issues/550>`_
 | June 26, 2021 : feat: Add `payload` filter `#398 <https://github.com/mergeability/mergeable/issues/398>`_
 | March 31, 2021 : feat: add chart support to prometheus servicemonitor `#535 <https://github.com/mergeability/mergeable/pull/535>`_
 | March 30, 2021 : fix: codeowners team

--- a/docs/validators/stale.rst
+++ b/docs/validators/stale.rst
@@ -6,6 +6,7 @@ Stale
     - do: stale
       days: 20 # number of days ago.
       type: pull_request, issues # what items to search for.
+      ignore_drafts: true # if set to true, the stale check will ignore draft items
       ignore_milestones: true # if set to true, the stale check will ignore items that have an associated milestone
       ignore_projects: true # if set to true, the stale check will ignore items that have an associated project
       label: # optional property to filter the items that are actioned upon

--- a/lib/validators/stale.js
+++ b/lib/validators/stale.js
@@ -27,6 +27,7 @@ class Stale extends Validator {
         match: 'array',
         ignore: 'array'
       },
+      ignore_drafts: 'boolean',
       ignore_milestones: 'boolean',
       ignore_projects: 'boolean',
       time_constraint: {
@@ -70,6 +71,9 @@ class Stale extends Validator {
     const labelMatchQuery = (label.match || []).map(label => `label:"${label}"`)
     const labelIgnoreQuery = (label.ignore || []).map(label => `-label:"${label}"`)
     let ignoreQuery = ''
+    if (validationSettings.ignore_drafts) {
+      ignoreQuery += '-is:draft '
+    }
     if (validationSettings.ignore_milestones) {
       ignoreQuery += 'no:milestone '
     }


### PR DESCRIPTION
See https://github.com/mergeability/mergeable/issues/565

This is a very small fix to ignore drafts in the stale validator.