### PR TITLE
chore: Add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish NPM package
+
+on:
+  push:
+    branches: ['master']
+
+jobs:
+  build:
+    name: publish the package to NPM
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.15.4]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/__tests__/unit/github/api.test.js
+++ b/__tests__/unit/github/api.test.js
@@ -657,7 +657,7 @@ describe('listPR', () => {
 
   test('that error are re-thrown', async () => {
     const context = Helper.mockContext()
-    context.octokit.pulls.list = jest.fn().mockRejectedValue({status: 402})
+    context.octokit.pulls.list = jest.fn().mockRejectedValue({ status: 402 })
 
     try {
       await GithubAPI.listPR(context)
@@ -676,13 +676,13 @@ describe('listReviews', () => {
       'review 2'
     ]
 
-    let res = await GithubAPI.listReviews(Helper.mockContext({ reviews }))
+    const res = await GithubAPI.listReviews(Helper.mockContext({ reviews }))
     expect(res).toEqual(reviews)
   })
 
   test('that error are re-thrown', async () => {
     const context = Helper.mockContext()
-    context.octokit.pulls.listReviews.endpoint.merge = jest.fn().mockRejectedValue({status: 402})
+    context.octokit.pulls.listReviews.endpoint.merge = jest.fn().mockRejectedValue({ status: 402 })
 
     try {
       await GithubAPI.listReviews(context)
@@ -708,7 +708,7 @@ describe('listCommits', () => {
       }
     ]
 
-    let res = await GithubAPI.listCommits(Helper.mockContext({ commits }))
+    const res = await GithubAPI.listCommits(Helper.mockContext({ commits }))
     expect(res.length).toEqual(1)
     expect(res[0].date).toEqual(date)
     expect(res[0].message).toEqual('fix: this')
@@ -716,7 +716,7 @@ describe('listCommits', () => {
 
   test('that error are NOT re-thrown', async () => {
     const context = Helper.mockContext()
-    context.octokit.pulls.listCommits.endpoint.merge = jest.fn().mockRejectedValue({status: 402})
+    context.octokit.pulls.listCommits.endpoint.merge = jest.fn().mockRejectedValue({ status: 402 })
 
     try {
       await GithubAPI.listCommits(context)

--- a/__tests__/unit/github/api.test.js
+++ b/__tests__/unit/github/api.test.js
@@ -647,3 +647,83 @@ describe('getPR', () => {
     }
   })
 })
+
+describe('listPR', () => {
+  test('return correct data if no error', async () => {
+    const res = await GithubAPI.listPR(Helper.mockContext())
+
+    expect(res.data).toEqual([])
+  })
+
+  test('that error are re-thrown', async () => {
+    const context = Helper.mockContext()
+    context.octokit.pulls.list = jest.fn().mockRejectedValue({status: 402})
+
+    try {
+      await GithubAPI.listPR(context)
+      // Fail test if above expression doesn't throw anything.
+      expect(true).toBe(false)
+    } catch (e) {
+      expect(e.status).toBe(402)
+    }
+  })
+})
+
+describe('listReviews', () => {
+  test('return correct data if no error', async () => {
+    const reviews = [
+      'review 1',
+      'review 2'
+    ]
+
+    let res = await GithubAPI.listReviews(Helper.mockContext({ reviews }))
+    expect(res).toEqual(reviews)
+  })
+
+  test('that error are re-thrown', async () => {
+    const context = Helper.mockContext()
+    context.octokit.pulls.listReviews.endpoint.merge = jest.fn().mockRejectedValue({status: 402})
+
+    try {
+      await GithubAPI.listReviews(context)
+      // Fail test if above expression doesn't throw anything.
+      expect(true).toBe(false)
+    } catch (e) {
+      expect(e.status).toBe(402)
+    }
+  })
+})
+
+describe('listCommits', () => {
+  test('return correct data if no error', async () => {
+    const date = Date.now()
+    const commits = [
+      {
+        commit: {
+          author: {
+            date
+          },
+          message: 'fix: this'
+        }
+      }
+    ]
+
+    let res = await GithubAPI.listCommits(Helper.mockContext({ commits }))
+    expect(res.length).toEqual(1)
+    expect(res[0].date).toEqual(date)
+    expect(res[0].message).toEqual('fix: this')
+  })
+
+  test('that error are NOT re-thrown', async () => {
+    const context = Helper.mockContext()
+    context.octokit.pulls.listCommits.endpoint.merge = jest.fn().mockRejectedValue({status: 402})
+
+    try {
+      await GithubAPI.listCommits(context)
+      // Fail test if above expression doesn't throw anything.
+      expect(true).toBe(false)
+    } catch (e) {
+      expect(e.status).toBe(402)
+    }
+  })
+})

--- a/lib/github/api.js
+++ b/lib/github/api.js
@@ -447,7 +447,7 @@ class GithubAPI {
     debugLog(context, callFn)
 
     try {
-      return context.octokit.pulls.list(context.repo({
+      return await context.octokit.pulls.list(context.repo({
         base: context.payload.ref
       }))
     } catch (err) {

--- a/lib/github/api.js
+++ b/lib/github/api.js
@@ -440,6 +440,54 @@ class GithubAPI {
       log.info(errorLog)
     }
   }
+
+  static async listPR (context) {
+    const callFn = 'pulls.list'
+
+    debugLog(context, callFn)
+
+    try {
+      return context.octokit.pulls.list(context.repo({
+        base: context.payload.ref
+      }))
+    } catch (err) {
+      return checkCommonError(err, context, callFn)
+    }
+  }
+
+  static async listReviews (context, pullNumber) {
+    const callFn = 'pulls.listReviews'
+
+    debugLog(context, callFn)
+
+    try {
+      return await context.octokit.paginate(
+        context.octokit.pulls.listReviews.endpoint.merge(
+          context.repo({ pull_number: pullNumber })
+        ),
+        res => res.data
+      )
+    } catch (err) {
+      return checkCommonError(err, context, callFn)
+    }
+  }
+
+  static async listCommits (context, pullNumber) {
+    const callFn = 'pulls.listCommits'
+
+    debugLog(context, callFn)
+
+    try {
+      return await context.octokit.paginate(
+        context.octokit.pulls.listCommits.endpoint.merge(
+          context.repo({ pull_number: pullNumber })
+        ),
+        res => res.data.map(o => ({ message: o.commit.message, date: o.commit.author.date }))
+      )
+    } catch (err) {
+      return checkCommonError(err, context, callFn)
+    }
+  }
 }
 
 module.exports = GithubAPI

--- a/lib/interceptors/interceptor.js
+++ b/lib/interceptors/interceptor.js
@@ -1,3 +1,4 @@
+const GithubAPI = require('../github/api')
 /**
  * The Interceptor class defines the interface for all inheriting interceptors that
  * mutates the probot context with additional meta data or changes existing property Values
@@ -9,6 +10,10 @@
  * Interceptors are cached instances and should be treated as singletons and is NOT thread safe. Instance variables should be treated as constants.
  */
 class Interceptor {
+  constructor () {
+    this.githubAPI = GithubAPI
+  }
+
   /**
    * All Interceptors should overwrite this method and mutate the context as needed.
    * By default returns the context unchanged.

--- a/lib/interceptors/push.js
+++ b/lib/interceptors/push.js
@@ -29,9 +29,7 @@ class Push extends Interceptor {
 
     const registry = { filters: new Map(), validators: new Map(), actions: new Map() }
 
-    const res = await context.octokit.pulls.list(context.repo({
-      base: context.payload.ref
-    }))
+    const res = await this.githubAPI.listPR(context)
 
     const pulls = res.data
     await Promise.all(pulls.map(pullRequest => {

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -66,7 +66,7 @@ class Approvals extends Validator {
       delete validationSettings.limit
     }
 
-    let reviews = await this.githubAPI.listReviews(context, this.getPayload(context).number)
+    const reviews = await this.githubAPI.listReviews(context, this.getPayload(context).number)
 
     const {
       requiredReviewers,

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -66,12 +66,7 @@ class Approvals extends Validator {
       delete validationSettings.limit
     }
 
-    const reviews = await context.octokit.paginate(
-      context.octokit.pulls.listReviews.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data
-    )
+    let reviews = await this.githubAPI.listReviews(context, this.getPayload(context).number)
 
     const {
       requiredReviewers,

--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -44,7 +44,7 @@ class Commit extends Validator {
 
     const validatorContext = { name: 'commit' }
 
-    let commits = await this.githubAPI.listCommits(context, this.getPayload(context).number)
+    const commits = await this.githubAPI.listCommits(context, this.getPayload(context).number)
     let orderedCommits = _.orderBy(commits, ['date'], ['asc'])
 
     if (singleCommitOnly && orderedCommits.length !== 1) {

--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -44,12 +44,7 @@ class Commit extends Validator {
 
     const validatorContext = { name: 'commit' }
 
-    const commits = await context.octokit.paginate(
-      context.octokit.pulls.listCommits.endpoint.merge(
-        context.repo({ pull_number: this.getPayload(context).number })
-      ),
-      res => res.data.map(o => ({ message: o.commit.message, date: o.commit.author.date }))
-    )
+    let commits = await this.githubAPI.listCommits(context, this.getPayload(context).number)
     let orderedCommits = _.orderBy(commits, ['date'], ['asc'])
 
     if (singleCommitOnly && orderedCommits.length !== 1) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mergeable",
+  "name": "@mergeability/mergeable",
   "version": "2.0.0",
   "description": "",
   "author": "Justin Law <hello@justinlaw.org> (https://github.io/mergeability/mergeable), Shine Lee <aungshine@gmail.com>",


### PR DESCRIPTION
Every time master branch is `pushed`, if the version is different from current, it'll publish the npm package