### PR TITLE
feat: Add team assignment to `request_review` action

### DIFF
--- a/__fixtures__/e2e/pr.payload.json
+++ b/__fixtures__/e2e/pr.payload.json
@@ -124,7 +124,20 @@
       }
     ],
     "requested_teams": [
-
+      {
+        "id": 1,
+        "node_id": "MDQ6VGVhbTE=",
+        "url": "https://api.github.com/teams/1",
+        "html_url": "https://github.com/orgs/github/teams/justice-league",
+        "name": "Justice League",
+        "slug": "justice-league",
+        "description": "A great team.",
+        "privacy": "closed",
+        "permission": "admin",
+        "members_url": "https://api.github.com/teams/1/members{/member}",
+        "repositories_url": "https://api.github.com/teams/1/repos",
+        "parent": null
+      }
     ],
     "labels": [
       {

--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -41,6 +41,7 @@ module.exports = {
           updated_at: options.updatedAt ? moment(options.updatedAt) : moment(),
           milestone: (options.milestone) ? options.milestone : null,
           requested_reviewers: options.requestedReviewers ? options.requestedReviewers : [],
+          requested_teams: options.requestedTeams ? options.requestedTeams : [],
           base: {
             repo: {
               full_name: options.baseRepo ? options.baseRepo : 'owner/test',

--- a/__tests__/unit/actions/request_review.test.js
+++ b/__tests__/unit/actions/request_review.test.js
@@ -67,6 +67,40 @@ test('that non collaborator is not requested reviews', async () => {
   expect(context.octokit.pulls.requestReviewers.mock.calls.length).toBe(0)
 })
 
+test('that requested teams are not requested again', async () => {
+  const requester = new RequestReview()
+  const options = {
+    requestedTeams: [{ slug: 'developers' }]
+  }
+
+  const teamSettings = {
+    teams: ['developers']
+  }
+
+  const context = createMockContext(options)
+
+  await requester.afterValidate(context, teamSettings, result)
+  expect(context.octokit.pulls.requestReviewers.mock.calls.length).toBe(0)
+})
+
+test('that requested team reviewers are added', async () => {
+  const requester = new RequestReview()
+  const options = {
+    requestedTeams: [{ slug: 'justice-league' }]
+  }
+
+  const teamSettings = {
+    reviewers: ['shine2lay'],
+    teams: ['developers']
+  }
+
+  const context = createMockContext(options)
+
+  await requester.afterValidate(context, teamSettings, result)
+  expect(context.octokit.pulls.requestReviewers.mock.calls.length).toBe(1)
+  expect(context.octokit.pulls.requestReviewers.mock.calls[0][0].team_reviewers[0]).toBe('developers')
+})
+
 const createMockContext = (options) => {
   const context = Helper.mockContext(options)
 

--- a/docs/actions/request_review.rst
+++ b/docs/actions/request_review.rst
@@ -1,10 +1,13 @@
 Request Review
 ^^^^^^^^^^^^^^^
 
+You can request specific reviews from specific reviewers, teams, or both
+
 ::
 
     - do: request_review
       reviewers: ['name1', 'name2']
+      teams: ['developers'] # team names without organization
 
 Supported Events:
 ::

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| August 6, 2021 : feat: Add team assignment to request_review action `#574 <https://github.com/mergeability/mergeable/pull/574>`_
 | July 19, 2021 : feat: Add ignore_drafts option to ignore drafts in stale validator `#565 <https://github.com/mergeability/mergeable/issues/565>`_
 | July 12, 2021 : feat: Filter specific status of files in changeset `#550 <https://github.com/mergeability/mergeable/issues/550>`_
 | June 26, 2021 : feat: Add `payload` filter `#398 <https://github.com/mergeability/mergeable/issues/398>`_

--- a/lib/actions/request_review.js
+++ b/lib/actions/request_review.js
@@ -17,7 +17,7 @@ class RequestReview extends Action {
 
     const requestedReviewer = payload.requested_reviewers.map(reviewer => reviewer.login)
 
-    let reviewers = settings.reviewers
+    let reviewers = settings.reviewers || []
 
     // remove author since they can not be requested for a review
     reviewers = reviewers.filter(reviewer => reviewer !== payload.user.login)
@@ -31,13 +31,20 @@ class RequestReview extends Action {
     // remove anyone in the array that is not a collaborator
     const collaboratorsToRequest = _.intersection(reviewerToRequest, collaborators)
 
-    if (collaboratorsToRequest.length === 0) {
+    const requestedTeams = payload.requested_teams.map(team => team.slug)
+
+    const teams = settings.teams || []
+
+    const teamsToRequest = _.difference(teams, requestedTeams)
+
+    if (collaboratorsToRequest.length === 0 && teamsToRequest.length === 0) {
       return
     }
     return this.githubAPI.requestReviewers(
       context,
       prNumber,
-      reviewerToRequest
+      reviewerToRequest,
+      teamsToRequest
     )
   }
 }

--- a/lib/github/api.js
+++ b/lib/github/api.js
@@ -425,13 +425,13 @@ class GithubAPI {
     }
   }
 
-  static async requestReviewers (context, pullNumber, reviewers) {
+  static async requestReviewers (context, pullNumber, reviewers, teamReviewers) {
     const callFn = 'pulls.requestReview'
 
     debugLog(context, callFn)
     try {
       return await context.octokit.pulls.requestReviewers(
-        context.repo({ pull_number: pullNumber, reviewers })
+        context.repo({ pull_number: pullNumber, reviewers, team_reviewers: teamReviewers })
       )
     } catch (err) {
       const errorLog = createLog(context, { callFn: callFn, errors: err.toString(), logType: logger.logTypes.REQUEST_REVIEW_FAIL_ERROR })


### PR DESCRIPTION
👋 This PR adds support for a `teams` option on the `request_review` action which will assign GitHub teams like the `reviewers` option does. 

I added tests which are passing, but I'm not sure about any other way to test since it's a marketplace app.

Closes #430 