### PR TITLE
feat: Support must_include and must_exclude regex as an array

### DIFF
--- a/__tests__/unit/validators/changeset.test.js
+++ b/__tests__/unit/validators/changeset.test.js
@@ -18,6 +18,29 @@ test('validate returns correctly', async () => {
   expect(validation.status).toBe('fail')
 })
 
+test('supports arrays', async () => {
+  const changeset = new Changeset()
+  const settings = {
+    do: 'changeset',
+    must_include: {
+      regex: [
+        'a.js',
+        'b.js',
+        'c.md'
+      ]
+    }
+  }
+
+  let validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+  expect(validation.status).toBe('pass')
+
+  validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'b.js']), settings)
+  expect(validation.status).toBe('pass')
+
+  validation = await changeset.processValidate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json']), settings)
+  expect(validation.status).toBe('fail')
+})
+
 test('fail gracefully if invalid regex', async () => {
   const changeset = new Changeset()
   const settings = {

--- a/__tests__/unit/validators/options_processor/options/must_exclude.test.js
+++ b/__tests__/unit/validators/options_processor/options/must_exclude.test.js
@@ -56,3 +56,17 @@ test('that regex_flag works as expected', async () => {
   const res = mustExclude.process(validatorContext, input, rule)
   expect(res.status).toBe('pass')
 })
+
+test('return pass if input array meets the criteria', async () => {
+  const rule = { must_exclude: { regex: ['test', 'D'] } }
+  const input = ['A', 'B', 'C']
+  const res = mustExclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('pass')
+})
+
+test('return fail if input array does not meet the criteria', async () => {
+  const rule = { must_exclude: { regex: ['^the', 'F', 'G'] } }
+  const input = ['A', 'B', 'the test']
+  const res = mustExclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('fail')
+})

--- a/__tests__/unit/validators/options_processor/options/must_include.test.js
+++ b/__tests__/unit/validators/options_processor/options/must_include.test.js
@@ -57,3 +57,18 @@ test('that regex_flag works as expected', async () => {
   const res = mustInclude.process(validatorContext, input, rule)
   expect(res.status).toBe('fail')
 })
+
+test('return pass if input array meets the criteria', async () => {
+  const rule = { must_include: { regex: ['^the\\stest$', 'nothing'] } }
+  const input = ['A', 'B', 'the test']
+  const res = mustInclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('pass')
+})
+
+test('return fail if input array does not meet the criteria', async () => {
+  const rule = { must_include: { regex: ['test', 'another'], message: 'failed array Test' } }
+  const input = ['E', 'F']
+  const res = mustInclude.process(validatorContext, input, rule)
+  expect(res.status).toBe('fail')
+  expect(res.description).toBe('failed array Test')
+})

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,6 @@
 CHANGELOG
 =====================================
-| August 6, 2021 : feat: Support must_include and must_exclude as an array on changeset `#575 <https://github.com/mergeability/mergeable/pull/575>`_
+| August 6, 2021 : feat: Support must_include and must_exclude regex as an array `#575 <https://github.com/mergeability/mergeable/pull/575>`_
 | July 19, 2021 : feat: Add ignore_drafts option to ignore drafts in stale validator `#565 <https://github.com/mergeability/mergeable/issues/565>`_
 | July 12, 2021 : feat: Filter specific status of files in changeset `#550 <https://github.com/mergeability/mergeable/issues/550>`_
 | June 26, 2021 : feat: Add `payload` filter `#398 <https://github.com/mergeability/mergeable/issues/398>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,6 @@
 CHANGELOG
 =====================================
-| August 6, 2021 : feat: Add team support to request_review action `#574 <https://github.com/mergeability/mergeable/pull/574>`_
+| August 6, 2021 : feat: Support must_include and must_exclude as an array on changeset `#575 <https://github.com/mergeability/mergeable/pull/575>`_
 | July 19, 2021 : feat: Add ignore_drafts option to ignore drafts in stale validator `#565 <https://github.com/mergeability/mergeable/issues/565>`_
 | July 12, 2021 : feat: Filter specific status of files in changeset `#550 <https://github.com/mergeability/mergeable/issues/550>`_
 | June 26, 2021 : feat: Add `payload` filter `#398 <https://github.com/mergeability/mergeable/issues/398>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| August 6, 2021 : feat: Add team support to request_review action `#574 <https://github.com/mergeability/mergeable/pull/574>`_
 | July 19, 2021 : feat: Add ignore_drafts option to ignore drafts in stale validator `#565 <https://github.com/mergeability/mergeable/issues/565>`_
 | July 12, 2021 : feat: Filter specific status of files in changeset `#550 <https://github.com/mergeability/mergeable/issues/550>`_
 | June 26, 2021 : feat: Add `payload` filter `#398 <https://github.com/mergeability/mergeable/issues/398>`_

--- a/docs/options/must_exclude.rst
+++ b/docs/options/must_exclude.rst
@@ -11,6 +11,19 @@ MustExclude
         message: |
             Your pull request doesn't adhere to the branch naming convention described <a href="some link">there</a>!k
 
+You can also use an array of regex matchers. If any of them match, the validation will fail.
+
+::
+
+    - do: headRef
+      must_exclude:
+        regex:
+          - "^bug"
+          - "^breaking"
+          - "^test"
+        message: |
+            Your pull request doesn't adhere to the branch naming convention described <a href="some link">there</a>!k
+
 .. list-table:: Supported Params
    :widths: 25 50 25 25
    :header-rows: 1
@@ -20,9 +33,9 @@ MustExclude
      - Required
      - Default Message
    * - regex
-     - Regex enabled message to validate input with
+     - Regex or array enabled message to validate input with
      - Yes
-     - 
+     -
    * - message
      - Message to show if the validation fails
      - No

--- a/docs/options/must_include.rst
+++ b/docs/options/must_include.rst
@@ -11,6 +11,19 @@ MustInclude
         message: |
             Your pull request doesn't adhere to the branch naming convention described <a href="some link">there</a>!k
 
+You can also use an array of regex matchers. If any of them match, the validation will pass.
+
+::
+
+    - do: headRef
+      must_include:
+        regex:
+          - "^feature"
+          - "^hotfix"
+          - "^fix"
+        message: |
+            Your pull request doesn't adhere to the branch naming convention described <a href="some link">there</a>!k
+
 .. list-table:: Supported Params
    :widths: 25 50 25 25
    :header-rows: 1
@@ -20,9 +33,9 @@ MustInclude
      - Required
      - Default Message
    * - regex
-     - Regex enabled message to validate input with
+     - Regex or array enabled message to validate input with
      - Yes
-     - 
+     -
    * - message
      - Message to show if the validation fails
      - No

--- a/lib/validators/baseRef.js
+++ b/lib/validators/baseRef.js
@@ -9,12 +9,12 @@ class BaseRef extends Validator {
     ]
     this.supportedSettings = {
       must_include: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },
       must_exclude: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       }

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -18,7 +18,7 @@ class Changeset extends Validator {
         message: 'string'
       },
       must_exclude: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -13,7 +13,7 @@ class Changeset extends Validator {
         message: 'string'
       },
       must_include: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },

--- a/lib/validators/contents.js
+++ b/lib/validators/contents.js
@@ -19,12 +19,12 @@ class Contents extends Validator {
         ignore: 'array'
       },
       must_include: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },
       must_exclude: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },

--- a/lib/validators/description.js
+++ b/lib/validators/description.js
@@ -19,12 +19,12 @@ class Description extends Validator {
         message: 'string'
       },
       must_include: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },
       must_exclude: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },

--- a/lib/validators/headRef.js
+++ b/lib/validators/headRef.js
@@ -14,12 +14,12 @@ class HeadRef extends Validator {
         message: 'string'
       },
       must_include: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },
       must_exclude: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       }

--- a/lib/validators/label.js
+++ b/lib/validators/label.js
@@ -19,12 +19,12 @@ class Label extends Validator {
         message: 'string'
       },
       must_include: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },
       must_exclude: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },

--- a/lib/validators/milestone.js
+++ b/lib/validators/milestone.js
@@ -20,12 +20,12 @@ class Milestone extends Validator {
         message: 'string'
       },
       must_include: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },
       must_exclude: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },

--- a/lib/validators/options_processor/options/must_exclude.js
+++ b/lib/validators/options_processor/options/must_exclude.js
@@ -11,34 +11,37 @@ class MustExclude {
       throw new Error(REGEX_NOT_FOUND_ERROR)
     }
 
-    let isMergeable
+    const regexList = [].concat(regex)
 
-    const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name} ${filter.all ? 'all' : ''}must exclude '${regex}'`
-    if (!description) description = `${validatorContext.name} ${filter.all ? 'all' : ''}does not exclude "${regex}"`
-    let regexObj
+    const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name} ${filter.all ? 'all' : ''}must exclude '${regexList.join(', ')}'`
+    if (!description) description = `${validatorContext.name} ${filter.all ? 'all' : ''}does not exclude "${regexList.join(', ')}"`
 
-    try {
-      let regexFlag = 'i'
-      if (filter.regex_flag) {
-        regexFlag = filter.regex_flag === 'none' ? '' : filter.regex_flag
+    const isMergeable = regexList.every((regex) => {
+      let regexObj
+
+      try {
+        let regexFlag = 'i'
+        if (filter.regex_flag) {
+          regexFlag = filter.regex_flag === 'none' ? '' : filter.regex_flag
+        }
+
+        regexObj = new RegExp(regex, regexFlag)
+      } catch (err) {
+        throw new Error(`Failed to create a regex expression with the provided regex: ${regex}`)
       }
 
-      regexObj = new RegExp(regex, regexFlag)
-    } catch (err) {
-      throw new Error(`Failed to create a regex expression with the provided regex: ${regex}`)
-    }
-
-    if (typeof input === 'string') {
-      isMergeable = !regexObj.test(input)
-    } else if (Array.isArray(input)) {
-      if (filter.all) {
-        isMergeable = input.every(label => !regexObj.test(label))
+      if (typeof input === 'string') {
+        return !regexObj.test(input)
+      } else if (Array.isArray(input)) {
+        if (filter.all) {
+          return input.every(label => !regexObj.test(label))
+        } else {
+          return !input.some(label => regexObj.test(label))
+        }
       } else {
-        isMergeable = !input.some(label => regexObj.test(label))
+        throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
       }
-    } else {
-      throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
-    }
+    })
 
     return {
       status: isMergeable ? 'pass' : 'fail',

--- a/lib/validators/options_processor/options/must_include.js
+++ b/lib/validators/options_processor/options/must_include.js
@@ -11,34 +11,37 @@ class MustInclude {
       throw new Error(REGEX_NOT_FOUND_ERROR)
     }
 
-    let isMergeable
+    const regexList = [].concat(regex)
 
-    const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name} ${filter.all ? 'all' : ''}must include '${regex}'`
-    if (!description) description = `${validatorContext.name} ${filter.all ? 'all' : ''}does not include "${regex}"`
-    let regexObj
+    const DEFAULT_SUCCESS_MESSAGE = `${validatorContext.name} ${filter.all ? 'all' : ''}must include '${regexList.join(', ')}'`
+    if (!description) description = `${validatorContext.name} ${filter.all ? 'all' : ''}does not include "${regexList.join(', ')}"`
 
-    try {
-      let regexFlag = 'i'
-      if (filter.regex_flag) {
-        regexFlag = filter.regex_flag === 'none' ? '' : filter.regex_flag
+    const isMergeable = regexList.some((regex) => {
+      let regexObj
+
+      try {
+        let regexFlag = 'i'
+        if (filter.regex_flag) {
+          regexFlag = filter.regex_flag === 'none' ? '' : filter.regex_flag
+        }
+
+        regexObj = new RegExp(regex, regexFlag)
+      } catch (err) {
+        throw new Error(`Failed to create a regex expression with the provided regex: ${regex}`)
       }
 
-      regexObj = new RegExp(regex, regexFlag)
-    } catch (err) {
-      throw new Error(`Failed to create a regex expression with the provided regex: ${regex}`)
-    }
-
-    if (typeof input === 'string') {
-      isMergeable = regexObj.test(input)
-    } else if (Array.isArray(input)) {
-      if (filter.all) {
-        isMergeable = input.every(label => regexObj.test(label))
+      if (typeof input === 'string') {
+        return regexObj.test(input)
+      } else if (Array.isArray(input)) {
+        if (filter.all) {
+          return input.every(label => regexObj.test(label))
+        } else {
+          return input.some(label => regexObj.test(label))
+        }
       } else {
-        isMergeable = input.some(label => regexObj.test(label))
+        throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
       }
-    } else {
-      throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
-    }
+    })
 
     return {
       status: isMergeable ? 'pass' : 'fail',

--- a/lib/validators/title.js
+++ b/lib/validators/title.js
@@ -19,12 +19,12 @@ class Title extends Validator {
         message: 'string'
       },
       must_include: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },
       must_exclude: {
-        regex: 'string',
+        regex: ['string', 'array'],
         regex_flag: 'string',
         message: 'string'
       },


### PR DESCRIPTION
Hi! :wave: Another PR. This solves our use case raised in #573 and allows `must_include` to be either a `string` or an `array.

I imagine this would be used in other places, but I'm not sure where.