### PR TITLE
feat: New labels API 

### DIFF
--- a/docs/actions/labels.rst
+++ b/docs/actions/labels.rst
@@ -1,6 +1,54 @@
 Labels
 ^^^^^^^^
 
+You can add, remove, and delete labels with one action.
+
+.. warning::
+    Using multiple ``do: labels`` in the same operation is not idempotent.
+    Use only one ``labels`` action per block for accurate labeling.
+
+You can add new labels, preserving existing ones
+
+::
+
+    - do: labels
+      add: 'Ready for Review'
+
+You can delete existing labels
+
+::
+
+    - do: labels
+      delete: [ 'Ready for Review', 'Triage' ]
+
+You can replace all current labels with new ones
+
+::
+
+    - do: labels
+      replace: [ 'Triage', 'Needs Deploy' ]
+
+You can also use any combination of these options. They can be listed in any
+order, but the action is always evaluated in the order of ``replace`` → ``add``
+→ ``delete``.
+
+::
+
+    - do: labels
+      replace: [ 'New Task', 'Not Useful' ]
+      add: [ 'Work in Progress', 'Needs Deploy' ]
+      delete: 'Not Useful'
+
+    # result: [ 'New Task', 'Work in Progress', 'Needs Deploy' ]
+
+
+``labels`` and ``mode``
+"""""""""""""""""""""""
+
+.. warning::
+    Using ``labels`` with ``mode`` is deprecated and will be removed in v3.
+    Use the ``add``, ``replace``, and ``delete`` options above for labeling.
+
 You can also add a set of the labels on an item
 
 ::

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| August 10, 2021 : feat: New labels API `#577 <https://github.com/mergeability/mergeable/pull/577>`_
 | August 6, 2021 : feat: Add team assignment to request_review action `#574 <https://github.com/mergeability/mergeable/pull/574>`_
 | August 6, 2021 : feat: Support must_include and must_exclude regex as an array `#575 <https://github.com/mergeability/mergeable/pull/575>`_
 | July 19, 2021 : feat: Add ignore_drafts option to ignore drafts in stale validator `#565 <https://github.com/mergeability/mergeable/issues/565>`_

--- a/lib/actions/labels.js
+++ b/lib/actions/labels.js
@@ -6,6 +6,9 @@ const matchesPatterns = (label, patterns) => (
   patterns.some((pattern) => minimatch(label, pattern))
 )
 
+/**
+ * @deprecated
+ */
 const deleteLabels = async (context, issueNumber, labels, actionObj) => {
   const currentLabels = await actionObj.githubAPI.listLabelsOnIssue(context, issueNumber)
   // We get the current labels and filter out anything that matches
@@ -29,6 +32,30 @@ class Labels extends Action {
 
   async afterValidate (context, settings, name, results) {
     const items = this.getActionables(context, results)
+
+    if (settings.replace || settings.add || settings.delete) {
+      return Promise.all(
+        items.map(async issue => {
+          let labels
+
+          if (settings.replace) {
+            labels = [].concat(settings.replace)
+          } else {
+            labels = await this.githubAPI.listLabelsOnIssue(context, issue.number)
+          }
+
+          if (settings.add) {
+            labels = labels.concat(settings.add)
+          }
+
+          if (settings.delete) {
+            labels = labels.filter(label => !matchesPatterns(label, [].concat(settings.delete)))
+          }
+
+          return this.githubAPI.setLabels(context, issue.number, labels)
+        })
+      )
+    }
 
     const actions = {
       add: this.githubAPI.addLabels,


### PR DESCRIPTION
This adds the `add`, `replace`, `delete` options for the `labels` action. Documentation was extended to include the new info, and labeled the old API as deprecated. I tested a bunch of scenarios with this with a local deploy and it's working great!

Closes #576