### PR TITLE
Add boolean filter for payload

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -138,6 +138,7 @@ These Options are used with validators.
 Options List
 
 .. toctree::
+    options/boolean.rst
     options/begins_with.rst
     options/ends_with.rst
     options/jira.rst

--- a/docs/filters/payload.rst
+++ b/docs/filters/payload.rst
@@ -1,11 +1,11 @@
 Payload
 ^^^^^^^^^^^^^^
 
-Check against any available fields within the payload, each event can have different field, please refer to `github API documentation for<https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads>`_ available fields.
+Check against any available fields within the payload, each event can have different field, please refer to `github API documentation <https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads>`_ for available fields.
 
 An example to check if a pull_request_review event has `state` of `changes_requested`
 
-.. codeblock:: yml
+::
 
       - do: payload
         review:
@@ -13,11 +13,22 @@ An example to check if a pull_request_review event has `state` of `changes_reque
             must_include:
               regex: 'changes_requested'
 
+To check if a `pull_request` event is not a `draft`
+
+::
+
+      - do: payload
+        pull_request:
+          draft:
+            boolean:
+              match: false
 
 Each field must be checked using one of the following options
 
-.. codeblock:: yml
+::
 
+      boolean:
+        match: true/false
       must_include:
         regex: 'This text must be included'
         regex_flag: 'none' # Optional. Specify the flag for Regex. default is 'i', to disable default use 'none'

--- a/docs/options/boolean.rst
+++ b/docs/options/boolean.rst
@@ -1,0 +1,48 @@
+Boolean
+^^^^^^^
+
+``boolean`` can be used to validate if the input is exactly `true` or `false`. This does not pass truthy values.
+
+For example, if the `pull_request.draft` value is `false`:
+
+::
+
+    {
+      "action": "opened",
+      "number": 2,
+      "pull_request": {
+        "draft": false
+
+This will pass validation, because the value of `draft` exactly matches `false`:
+
+::
+
+    - do: payload
+      pull_request:
+        draft:
+          boolean:
+            match: false
+            message: 'Custom message...' # this is optional, a default message is used when not specified.
+
+
+.. list-table:: Supported Params
+   :widths: 25 50 25 25
+   :header-rows: 1
+
+   * - Param
+     - Description
+     - Required
+     - Default Message
+   * - match
+     - Bool value to check for
+     - Yes
+     -
+   * - message
+     - Message to show if the validation fails
+     - No
+     - The [INPUT NAME] must be [match]
+
+Supported Filters:
+::
+
+    'payload'

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -200,3 +200,29 @@ Add 2 checks to the PR
                   - do: title
                     begins_with:
                       match: [ 'some prefix' ]
+
+
+Only run rules if PR is not a draft
+"""""""""""""""""""""""
+Checks that the PR's draft state is false before running actions.
+
+::
+
+    version: 2
+    mergeable:
+      - when: pull_request.*, pull_request_review.*
+        name: 'Draft check'
+        validate:
+          - do: payload
+            pull_request:
+              draft:
+                boolean:
+                  match: false
+        pass:
+          - do: comment
+            payload:
+              body: This PR is NOT a draft!
+        fail:
+          - do: comment
+            payload:
+              body: This PR is STILL a draft!

--- a/lib/filters/payload.js
+++ b/lib/filters/payload.js
@@ -4,7 +4,7 @@ const constructError = require('./options_processor/options/lib/constructError')
 const _ = require('lodash')
 const { forEach } = require('p-iteration')
 
-const options = ['must_include', 'must_exclude']
+const options = ['boolean', 'must_include', 'must_exclude']
 
 async function recursveThruFields (filterObj, currentPath, output, payload, field) {
   await forEach(Object.keys(field), async key => {

--- a/lib/validators/options_processor/options/boolean.js
+++ b/lib/validators/options_processor/options/boolean.js
@@ -1,0 +1,32 @@
+const MATCH_NOT_FOUND_ERROR = 'Failed to run the test because \'match\' is not provided for \'boolean\' option. Please check README for more information about configuration'
+const UNKNOWN_INPUT_TYPE_ERROR = 'Input type invalid, expected boolean as input'
+
+class BooleanOption {
+  static process (validatorContext, input, rule) {
+    const filter = rule.boolean
+
+    const match = filter.match
+    let description = filter.message
+    if (match == null) {
+      throw new Error(MATCH_NOT_FOUND_ERROR)
+    }
+
+    let isMergeable
+
+    const DEFAULT_SUCCESS_MESSAGE = `The ${validatorContext.name} is ${match}`
+    if (!description) description = `The ${validatorContext.name} must be ${match}`
+
+    if (typeof input === 'boolean') {
+      isMergeable = input === match || input.toString() === match.toString()
+    } else {
+      throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
+    }
+
+    return {
+      status: isMergeable ? 'pass' : 'fail',
+      description: isMergeable ? DEFAULT_SUCCESS_MESSAGE : description
+    }
+  }
+}
+
+module.exports = BooleanOption


### PR DESCRIPTION
This adds a `Boolean` filter option for `payload` that can validate whether an attribute or subtree attribute is exactly `true` or `false`.

This also fixes an issue where the link [the Payload docs](https://mergeable.readthedocs.io/en/latest/filters/payload.html) was not displaying correctly, which made most of the rest of the page not appear. 

- [ ] Add tests if behavior is correct

Closes #565