### PR TITLE
fix: Check that getRouter is defined before attempting to access it

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| September 20, 2021 : fix: Check that getRouter is defined before attempting to access it `#587 <https://github.com/mergeability/mergeable/pull/587>`_
 | August 26, 2021 : fix: Await GithubAPI topics response `#585 <https://github.com/mergeability/mergeable/pull/585>`_
 | August 10, 2021 : feat: New labels API `#577 <https://github.com/mergeability/mergeable/pull/577>`_
 | August 6, 2021 : feat: Add team assignment to request_review action `#574 <https://github.com/mergeability/mergeable/pull/574>`_

--- a/index.js
+++ b/index.js
@@ -4,16 +4,18 @@ const githubRateLimitEndpoint = require('./lib/utils/githubRateLimitEndpoint')
 const prometheusMiddleware = require('express-prometheus-middleware')
 
 module.exports = (robot, { getRouter }) => {
-  const router = getRouter()
+  if (getRouter !== undefined) {
+    const router = getRouter()
 
-  if (process.env.ENABLE_GITHUB_RATELIMIT_ENDPOINT === 'true') {
-    // endpoint to fetch github given installation rate limit
-    router.get('/github-ratelimit/:installationId', githubRateLimitEndpoint(robot))
-  }
+    if (process.env.ENABLE_GITHUB_RATELIMIT_ENDPOINT === 'true') {
+      // endpoint to fetch github given installation rate limit
+      router.get('/github-ratelimit/:installationId', githubRateLimitEndpoint(robot))
+    }
 
-  if (process.env.ENABLE_METRICS_ENDPOINT === 'true') {
-    // expose prometheus metrics
-    router.use(prometheusMiddleware())
+    if (process.env.ENABLE_METRICS_ENDPOINT === 'true') {
+      // expose prometheus metrics
+      router.use(prometheusMiddleware())
+    }
   }
 
   logger.init(robot.log)


### PR DESCRIPTION
This fix allows running mergeable as a lambda function using probot/adapter-aws-lambda-serverless by checking that getRouter is defined (which it won't be if started within a lambda function).  This likely will also allow it to work in other serverless frameworks, however I didn't test against them so can't speak to that.

Fixes #586 