### PR TITLE
fix: use node version 14.17.6 for the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.15.4]
+        node-version: [14.17.6]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The latest version of semantic-release requires node >=14.17 (https://github.com/semantic-release/semantic-release/pull/2132)