### PR TITLE
feat: Add baseRef filter

### DIFF
--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -47,7 +47,7 @@ module.exports = {
               full_name: options.baseRepo ? options.baseRepo : 'owner/test',
               private: (options.repoPrivate) ? options.repoPrivate : false
             },
-            ref:  options.baseRef ? options.baseRef : 'baseRef',
+            ref: options.baseRef ? options.baseRef : 'baseRef',
             sha: 'sha2'
           },
           head: {

--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -47,7 +47,7 @@ module.exports = {
               full_name: options.baseRepo ? options.baseRepo : 'owner/test',
               private: (options.repoPrivate) ? options.repoPrivate : false
             },
-            ref: 'baseRef',
+            ref:  options.baseRef ? options.baseRef : 'baseRef',
             sha: 'sha2'
           },
           head: {

--- a/__tests__/unit/filters/baseRef.test.js
+++ b/__tests__/unit/filters/baseRef.test.js
@@ -1,0 +1,54 @@
+const BaseRef = require('../../../lib/filters/baseRef')
+const Helper = require('../../../__fixtures__/unit/helper')
+
+test('should fail with unexpected baseRef', async () => {
+  const baseRef = new BaseRef()
+  const settings = {
+    do: 'baseRef',
+    must_include: {
+      regex: 'some-other-ref'
+    }
+  }
+  const filter = await baseRef.processFilter(createMockContext('some-ref'), settings)
+  expect(filter.status).toBe('fail')
+})
+
+test('should pass with expected baseRef', async () => {
+  const baseRef = new BaseRef()
+  const settings = {
+    do: 'baseRef',
+    must_include: {
+      regex: 'some-ref'
+    }
+  }
+  const filter = await baseRef.processFilter(createMockContext('some-ref'), settings)
+  expect(filter.status).toBe('pass')
+})
+
+test('should fail with excluded baseRef', async () => {
+  const baseRef = new BaseRef()
+  const settings = {
+    do: 'baseRef',
+    must_exclude: {
+      regex: 'some-ref'
+    }
+  }
+  const filter = await baseRef.processFilter(createMockContext('some-ref'), settings)
+  expect(filter.status).toBe('fail')
+})
+
+test('should pass with excluded baseRef', async () => {
+  const baseRef = new BaseRef()
+  const settings = {
+    do: 'baseRef',
+    must_exclude: {
+      regex: 'some-other-ref'
+    }
+  }
+  const filter = await baseRef.processFilter(createMockContext('some-ref'), settings)
+  expect(filter.status).toBe('pass')
+})
+
+const createMockContext = (baseRef) => {
+  return Helper.mockContext({ baseRef })
+}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| November 12, 2021 : feat: Add baseRef filter `#596 <https://github.com/mergeability/mergeable/pull/596>`_
 | October 19, 2021 : feat: Add validator approval option to exclude users `#594 <https://github.com/mergeability/mergeable/pull/594>`_
 | October 12, 2021 : feat: Add boolean option for payload filter `#583 <https://github.com/mergeability/mergeable/pull/583>`_
 | September 27, 2021 : fix: use node version 14.17.6 for the release action `#591 <https://github.com/mergeability/mergeable/pull/591>`_

--- a/docs/filters/baseRef.rst
+++ b/docs/filters/baseRef.rst
@@ -1,0 +1,49 @@
+BaseRef
+^^^^^^^^^^^^^^
+
+::
+
+      - do: baseRef
+        must_include:
+            regex: 'some-ref'
+            message: 'Custom message...'
+        # all of the message sub-option is optional
+
+you can use ``and`` and ``or`` options to create more complex filters
+
+::
+
+    - do: baseRef
+      and:
+        - must_exclude:
+            regex: 'some-other-ref'
+            message: 'Custom message...'
+      or:
+        - must_include:
+            regex: 'some-ref'
+            message: 'Custom message...'
+        - must_include:
+            regex: 'some-other-ref'
+            message: 'Custom message...'
+
+you can also nest ``and`` and ``or`` options
+
+::
+
+    - do: baseRef
+      and:
+        - or:
+            - must_include:
+                regex: 'some-ref'
+                message: 'Custom message...'
+            - must_include:
+                regex: 'some-other-ref'
+                message: 'Custom message...'
+        - must_exclude:
+            regex: 'yet-another-ref'
+            message: 'Custom message...'
+
+Supported Events:
+::
+
+    'pull_request.*', 'pull_request_review.*'

--- a/lib/filters/baseRef.js
+++ b/lib/filters/baseRef.js
@@ -1,0 +1,30 @@
+const { Filter } = require('./filter')
+
+class BaseRef extends Filter {
+  constructor () {
+    super('baseRef')
+    this.supportedEvents = [
+      'pull_request.*',
+      'pull_request_review.*'
+    ]
+    this.supportedSettings = {
+      must_include: {
+        regex: 'string',
+        regex_flag: 'string',
+        message: 'string'
+      },
+      must_exclude: {
+        regex: 'string',
+        regex_flag: 'string',
+        message: 'string'
+      }
+    }
+  }
+
+  async filter (context, settings) {
+    const payload = this.getPayload(context)
+    return this.processOptions(context, payload.base.ref, settings)
+  }
+}
+
+module.exports = BaseRef


### PR DESCRIPTION
As a user of Mergeable i want to be able to execute validators only on PRs targeting a certain baseRef

### BaseRef
```
- do: baseRef
  must_include:
      regex: '^master$'
      message: 'Custom message...'
  # all of the message sub-option is optional
  ```