### PR TITLE
feat: Allow all option on must_include and must_include inside changeset validator

### DIFF
--- a/__tests__/unit/validators/changeset.test.js
+++ b/__tests__/unit/validators/changeset.test.js
@@ -94,6 +94,44 @@ test('that it validates ends_with correctly', async () => {
   expect(validation.status).toBe('pass')
 })
 
+test('that it validates must_include with all:true correctly', async () => {
+  const changeset = new Changeset()
+  const settings = {
+    do: 'changeset',
+    must_include: {
+      regex: '^\\w+\\.md$',
+      all: true
+    }
+  }
+
+  // This is all .md files, so should pass all: true
+  let validation = await changeset.processValidate(createMockContext(['test.md', 'another.md', 'something.md']), settings)
+  expect(validation.status).toBe('pass')
+
+  // This is not all .md files, so should fail all: true
+  validation = await changeset.processValidate(createMockContext(['test.md', 'not_md.js', 'another.md']), settings)
+  expect(validation.status).toBe('fail')
+})
+
+test('that it validates must_exclude with all:true correctly', async () => {
+  const changeset = new Changeset()
+  const settings = {
+    do: 'changeset',
+    must_exclude: {
+      regex: '^\\w+\\.md$',
+      all: true
+    }
+  }
+
+  // This doesn't contain any .md files, so should pass all: true
+  let validation = await changeset.processValidate(createMockContext(['test.js', 'another.py', 'something.txt']), settings)
+  expect(validation.status).toBe('pass')
+
+  // This contains 1 .md file, so you should fail exclude all
+  validation = await changeset.processValidate(createMockContext(['another.py', 'test.md', 'something.txt']), settings)
+  expect(validation.status).toBe('fail')
+})
+
 test('correct files are considered based on file status setting', async () => {
   const changeset = new Changeset()
   const settings = {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,9 @@
 CHANGELOG
 =====================================
-| February 6, 2022: feat: Add commit_title and commit_message options to merge action so the merge commit can be customized based on PR content `#612 <https://github.com/mergeability/mergeable/pull/612>`
-| December 12, 2021: feat: Add support for status events to baseRef validator `#395 <https://github.com/mergeability/mergeable/issues/395#issuecomment-991904249>` _
-| November 25, 2021: feat: Add more supported events to baseRef validator `#395 <https://github.com/mergeability/mergeable/issues/395#issuecomment-975763927>` _
+| February 8, 2022: feat: Allow all option on must_include and must_include inside changeset validator `#611 <https://github.com/mergeability/mergeable/pull/611>`_
+| February 6, 2022: feat: Add commit_title and commit_message options to merge action so the merge commit can be customized based on PR content `#612 <https://github.com/mergeability/mergeable/pull/612>`_
+| December 12, 2021: feat: Add support for status events to baseRef validator `#395 <https://github.com/mergeability/mergeable/issues/395#issuecomment-991904249>`_
+| November 25, 2021: feat: Add more supported events to baseRef validator `#395 <https://github.com/mergeability/mergeable/issues/395#issuecomment-975763927>`_
 | November 12, 2021 : feat: Add baseRef filter `#596 <https://github.com/mergeability/mergeable/pull/596>`_
 | October 19, 2021 : feat: Add validator approval option to exclude users `#594 <https://github.com/mergeability/mergeable/pull/594>`_
 | October 12, 2021 : feat: Add boolean option for payload filter `#583 <https://github.com/mergeability/mergeable/pull/583>`_

--- a/lib/validators/changeset.js
+++ b/lib/validators/changeset.js
@@ -15,12 +15,14 @@ class Changeset extends Validator {
       must_include: {
         regex: ['string', 'array'],
         regex_flag: 'string',
-        message: 'string'
+        message: 'string',
+        all: 'boolean'
       },
       must_exclude: {
         regex: ['string', 'array'],
         regex_flag: 'string',
-        message: 'string'
+        message: 'string',
+        all: 'boolean'
       },
       begins_with: {
         match: ['string', 'array'],


### PR DESCRIPTION
This adds the ability to use the `all` option on `must_include` and `must_exclude` inside the changeset validator. The code was already there, but it wasn't allowed in the schema. This allows it in the schema.

Relates to https://github.com/mergeability/mergeable/issues/595

@shine2lay 