### PR TITLE
feat: Add an option to use PR title as commit message

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -39,6 +39,8 @@ mergeable:
     pass:
       - do: merge
         merge_method: 'squash'
+        commit_title: 'HELLO!!! {{ title }} (#{{ number }})'
+        commit_message: '{{ body }}'
       - do: checks
         status: 'success'
 

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -39,8 +39,6 @@ mergeable:
     pass:
       - do: merge
         merge_method: 'squash'
-        commit_title: 'HELLO!!! {{ title }} (#{{ number }})'
-        commit_message: '{{ body }}'
       - do: checks
         status: 'success'
 

--- a/__tests__/unit/actions/merge.test.js
+++ b/__tests__/unit/actions/merge.test.js
@@ -100,6 +100,8 @@ test('check that merge_method option works correctly', async () => {
   await merge.afterValidate(context, settings)
   expect(context.octokit.pulls.merge.mock.calls.length).toBe(1)
   expect(context.octokit.pulls.merge.mock.calls[0][0].merge_method).toBe('squash')
+  expect(context.octokit.pulls.merge.mock.calls[0][0].commit_title).toBe(undefined)
+  expect(context.octokit.pulls.merge.mock.calls[0][0].commit_message).toBe(undefined)
 })
 
 test('check that commit_title and commit_message options work correctly', async () => {

--- a/__tests__/unit/actions/merge.test.js
+++ b/__tests__/unit/actions/merge.test.js
@@ -139,3 +139,21 @@ test('check that commit_title and commit_message options support templating', as
   expect(context.octokit.pulls.merge.mock.calls[0][0].commit_title).toBe('some pr (#10)')
   expect(context.octokit.pulls.merge.mock.calls[0][0].commit_message).toBe('some message')
 })
+
+test('check that commit_title and commit_message options support empty string', async () => {
+  const merge = new Merge()
+  const checkIfMerged = false
+  const context = Helper.mockContext({ checkIfMerged })
+  context.octokit.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean', state: 'open', title: 'some pr', body: 'some message', number: 10 } })
+  const settings = {
+    merge_method: 'squash',
+    commit_title: '',
+    commit_message: ''
+  }
+
+  await merge.afterValidate(context, settings)
+  expect(context.octokit.pulls.merge.mock.calls.length).toBe(1)
+  expect(context.octokit.pulls.merge.mock.calls[0][0].merge_method).toBe('squash')
+  expect(context.octokit.pulls.merge.mock.calls[0][0].commit_title).toBe('')
+  expect(context.octokit.pulls.merge.mock.calls[0][0].commit_message).toBe('')
+})

--- a/__tests__/unit/actions/merge.test.js
+++ b/__tests__/unit/actions/merge.test.js
@@ -101,3 +101,39 @@ test('check that merge_method option works correctly', async () => {
   expect(context.octokit.pulls.merge.mock.calls.length).toBe(1)
   expect(context.octokit.pulls.merge.mock.calls[0][0].merge_method).toBe('squash')
 })
+
+test('check that commit_title and commit_message options work correctly', async () => {
+  const merge = new Merge()
+  const checkIfMerged = false
+  const context = Helper.mockContext({ checkIfMerged })
+  context.octokit.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean', state: 'open' } })
+  const settings = {
+    merge_method: 'squash',
+    commit_title: 'hello world',
+    commit_message: 'foobar'
+  }
+
+  await merge.afterValidate(context, settings)
+  expect(context.octokit.pulls.merge.mock.calls.length).toBe(1)
+  expect(context.octokit.pulls.merge.mock.calls[0][0].merge_method).toBe('squash')
+  expect(context.octokit.pulls.merge.mock.calls[0][0].commit_title).toBe('hello world')
+  expect(context.octokit.pulls.merge.mock.calls[0][0].commit_message).toBe('foobar')
+})
+
+test('check that commit_title and commit_message options support templating', async () => {
+  const merge = new Merge()
+  const checkIfMerged = false
+  const context = Helper.mockContext({ checkIfMerged })
+  context.octokit.pulls.get.mockReturnValue({ data: { mergeable_state: 'clean', state: 'open', title: 'some pr', body: 'some message', number: 10 } })
+  const settings = {
+    merge_method: 'squash',
+    commit_title: '{{ title }} (#{{ number }})',
+    commit_message: '{{ body }}'
+  }
+
+  await merge.afterValidate(context, settings)
+  expect(context.octokit.pulls.merge.mock.calls.length).toBe(1)
+  expect(context.octokit.pulls.merge.mock.calls[0][0].merge_method).toBe('squash')
+  expect(context.octokit.pulls.merge.mock.calls[0][0].commit_title).toBe('some pr (#10)')
+  expect(context.octokit.pulls.merge.mock.calls[0][0].commit_message).toBe('some message')
+})

--- a/docs/actions/merge.rst
+++ b/docs/actions/merge.rst
@@ -6,8 +6,9 @@ Merge
     - do: merge
       merge_method: 'merge' # Optional, default is 'merge'. Other options : 'rebase', 'squash'
       # template variables for next two items come from result of https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
-      commit_title: '{{ title }} (#{{ number }})' # Optional, override commit title
-      commit_message: '{{ body }}' # Optional, override commit message
+      # use triple curly braces to avoid html escaping
+      commit_title: '{{{ title }}} (#{{{ number }}})' # Optional, override commit title
+      commit_message: '{{{ body }}}' # Optional, override commit message
 
 
 Supported Events:

--- a/docs/actions/merge.rst
+++ b/docs/actions/merge.rst
@@ -4,7 +4,11 @@ Merge
 ::
 
     - do: merge
-      merge_method: 'merge' # Optional , default is 'merge'. Other options : 'rebase', 'squash'
+      merge_method: 'merge' # Optional, default is 'merge'. Other options : 'rebase', 'squash'
+      # template variables for next two items come from result of https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
+      commit_title: '{{ title }} (#{{ number }})' # Optional, override commit title
+      commit_message: '{{ body }}' # Optional, override commit message
+
 
 Supported Events:
 ::

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| February 6, 2022: feat: Add commit_title and commit_message options to merge action so the merge commit can be customized based on PR content `#612 <https://github.com/mergeability/mergeable/pull/612>`
 | December 12, 2021: feat: Add support for status events to baseRef validator `#395 <https://github.com/mergeability/mergeable/issues/395#issuecomment-991904249>` _
 | November 25, 2021: feat: Add more supported events to baseRef validator `#395 <https://github.com/mergeability/mergeable/issues/395#issuecomment-975763927>` _
 | November 12, 2021 : feat: Add baseRef filter `#596 <https://github.com/mergeability/mergeable/pull/596>`_

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -11,11 +11,11 @@ const mergePR = async (context, prNumber, mergeMethod, commitTitle, commitMessag
 
     if (pullRequest.data.mergeable_state !== 'blocked' && pullRequest.data.state === 'open') {
       const mergeParams = { pull_number: prNumber, merge_method: mergeMethod }
-      if (commitTitle) {
+      if (commitTitle !== undefined) {
         const template = handlebars.compile(commitTitle)
         mergeParams.commit_title = template(pullRequest.data)
       }
-      if (commitMessage) {
+      if (commitMessage !== undefined) {
         const template = handlebars.compile(commitMessage)
         mergeParams.commit_message = template(pullRequest.data)
       }
@@ -47,8 +47,6 @@ class Merge extends Action {
       throw new UnSupportedSettingError(`Unknown Merge method, supported options are ${MERGE_METHOD_OPTIONS.join(', ')}`)
     }
     const mergeMethod = settings.merge_method ? settings.merge_method : 'merge'
-    const commitTitle = settings.commit_title ? settings.commit_title : ''
-    const commitMessage = settings.commit_message ? settings.commit_message : ''
     let relatedPullRequests = []
     if (context.eventName === 'status') {
       const commitSHA = context.payload.sha
@@ -71,8 +69,8 @@ class Merge extends Action {
           context,
           issue.number,
           mergeMethod,
-          commitTitle,
-          commitMessage,
+          settings.commit_title,
+          settings.commit_message,
           this
         )
       })

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -3,13 +3,18 @@ const UnSupportedSettingError = require('../errors/unSupportedSettingError')
 
 const MERGE_METHOD_OPTIONS = ['merge', 'rebase', 'squash']
 
-const mergePR = async (context, prNumber, mergeMethod, actionObj) => {
+const mergePR = async (context, pr, mergeMethod, usePrAsCommitMessage, actionObj) => {
   const isMerged = await actionObj.githubAPI.checkIfMerged(context, prNumber)
   if (!isMerged) {
     const pullRequest = await actionObj.githubAPI.getPR(context, prNumber)
 
     if (pullRequest.data.mergeable_state !== 'blocked' && pullRequest.data.state === 'open') {
-      await actionObj.githubAPI.mergePR(context, context.repo({ pull_number: prNumber, merge_method: mergeMethod }))
+      mergeParams = { pull_number: pr.number, merge_method: mergeMethod }
+      if (usePrAsCommitMessage) {
+        mergeParams.commit_title = pr.title
+        mergeParams.commit_message = pr.body
+      }
+      await actionObj.githubAPI.mergePR(context, context.repo(mergeParams))
     }
   }
 }
@@ -37,6 +42,7 @@ class Merge extends Action {
       throw new UnSupportedSettingError(`Unknown Merge method, supported options are ${MERGE_METHOD_OPTIONS.join(', ')}`)
     }
     const mergeMethod = settings.merge_method ? settings.merge_method : 'merge'
+    const usePrAsCommitMessage = settings.use_pr_as_commit_message ? settings.use_pr_as_commit_message : false
     let relatedPullRequests = []
     if (context.eventName === 'status') {
       const commitSHA = context.payload.sha
@@ -57,8 +63,9 @@ class Merge extends Action {
       relatedPullRequests.map(issue => {
         mergePR(
           context,
-          issue.number,
+          issue,
           mergeMethod,
+          usePrAsCommitMessage,
           this
         )
       })

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -1,18 +1,23 @@
 const { Action } = require('./action')
 const UnSupportedSettingError = require('../errors/unSupportedSettingError')
+const handlebars = require('handlebars')
 
 const MERGE_METHOD_OPTIONS = ['merge', 'rebase', 'squash']
 
-const mergePR = async (context, pr, mergeMethod, usePrAsCommitMessage, actionObj) => {
+const mergePR = async (context, prNumber, mergeMethod, commitTitle, commitMessage, actionObj) => {
   const isMerged = await actionObj.githubAPI.checkIfMerged(context, prNumber)
   if (!isMerged) {
     const pullRequest = await actionObj.githubAPI.getPR(context, prNumber)
 
     if (pullRequest.data.mergeable_state !== 'blocked' && pullRequest.data.state === 'open') {
-      mergeParams = { pull_number: pr.number, merge_method: mergeMethod }
-      if (usePrAsCommitMessage) {
-        mergeParams.commit_title = pr.title
-        mergeParams.commit_message = pr.body
+      const mergeParams = { pull_number: prNumber, merge_method: mergeMethod }
+      if (commitTitle) {
+        const template = handlebars.compile(commitTitle)
+        mergeParams.commit_title = template(pullRequest.data)
+      }
+      if (commitMessage) {
+        const template = handlebars.compile(commitMessage)
+        mergeParams.commit_message = template(pullRequest.data)
       }
       await actionObj.githubAPI.mergePR(context, context.repo(mergeParams))
     }
@@ -42,7 +47,8 @@ class Merge extends Action {
       throw new UnSupportedSettingError(`Unknown Merge method, supported options are ${MERGE_METHOD_OPTIONS.join(', ')}`)
     }
     const mergeMethod = settings.merge_method ? settings.merge_method : 'merge'
-    const usePrAsCommitMessage = settings.use_pr_as_commit_message ? settings.use_pr_as_commit_message : false
+    const commitTitle = settings.commit_title ? settings.commit_title : ''
+    const commitMessage = settings.commit_message ? settings.commit_message : ''
     let relatedPullRequests = []
     if (context.eventName === 'status') {
       const commitSHA = context.payload.sha
@@ -63,9 +69,10 @@ class Merge extends Action {
       relatedPullRequests.map(issue => {
         mergePR(
           context,
-          issue,
+          issue.number,
           mergeMethod,
-          usePrAsCommitMessage,
+          commitTitle,
+          commitMessage,
           this
         )
       })


### PR DESCRIPTION
Added a merge setting options called `commit_title` and `commit_message` that allow the user to control the merged commit message. These are templates that use the PR object as variables, so you can use the PR title, body, and number, for example. This allows users to set rules requiring certain commit messages without forcing the user to squash and `git push --force`. If we want the commit message to always contain the ticket, just force the user to update the PR title instead of pushing again.