### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   init:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     outputs:
       do_docker: ${{ steps.vars.outputs.IS_DOCKERHUB_PUSH }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '**' ]
   
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Tests and Code Coverage


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
