### PR TITLE
chore(fix): Bump bitnami/redis to version 16.12.1

### DIFF
--- a/helm/mergeable/Chart.lock
+++ b/helm/mergeable/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 9.5.0
-digest: sha256:91e301092990a1597e49c970c575effa213228ea7ef302094aa2278b73458065
-generated: "2021-02-12T10:07:57.64309+01:00"
+  version: 16.12.1
+digest: sha256:3abd8630fe9d83d8fa557c41a5556df9953bd9a90d3bdfcc8bf99cedee1f5af3
+generated: "2022-06-13T09:45:25.520228989+02:00"

--- a/helm/mergeable/Chart.yaml
+++ b/helm/mergeable/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: 1.16.0
 # Dependencies for the chart
 dependencies:
   - name: redis
-    version: 9.5.0
+    version: 16.12.1
     repository: https://charts.bitnami.com/bitnami

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -107,9 +107,6 @@ prometheus:
 
 ## Redis for cache
 redis:
-  usePassword: false
-  cluster:
-    enabled: false
   master:
     podLabels: {}
     service:
@@ -119,3 +116,5 @@ redis:
       enabled: true
       subPath: "mergeable"
       size: 512Mi
+  replica:
+    replicaCount: 0


### PR DESCRIPTION
Following the enforcement of the new [bitnami helm charts repository retention policy](https://github.com/bitnami/charts/issues/10539), this chart doesn't install properly anymore and bumping the version of the `bitnami/redis` chart is easy enough.