### PR TITLE
feat: Add newest_only commit validation setting

### DIFF
--- a/__tests__/unit/validators/commit.test.js
+++ b/__tests__/unit/validators/commit.test.js
@@ -76,6 +76,44 @@ test('oldest_only sub option', async () => {
   expect(validation.status).toBe('pass')
 })
 
+test('newest_only sub option', async () => {
+  const commit = new Commit()
+  const settings = {
+    do: 'commit',
+    message: {
+      regex: 'feat:',
+      newest_only: true
+    }
+  }
+  const date = Date.now()
+  const commits = [
+    {
+      commit: {
+        author: {
+          date
+        },
+        message: 'fix: that'
+      }
+    },
+    {
+      commit: {
+        author: {
+          date: date + 1
+        },
+        message: 'fix: this'
+      }
+    }
+  ]
+
+  let validation = await commit.processValidate(createMockContext(commits), settings)
+  expect(validation.status).toBe('fail')
+
+  commits[1].commit.message = 'feat: this'
+
+  validation = await commit.processValidate(createMockContext(commits), settings)
+  expect(validation.status).toBe('pass')
+})
+
 test('skip_merge sub option', async () => {
   const commit = new Commit()
   const settings = {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| August 2, 2022: feat: Add newest_only commit validation setting `#649 <https://github.com/mergeability/mergeable/pull/649>`_
 | April 7, 2022: feat: Support adding deployment labels from values `#631 <https://github.com/mergeability/mergeable/pull/631>`_
 | March 22, 2022: fix: pass comment instance to removeErrorComments `#626 <https://github.com/mergeability/mergeable/pull/626>`_
 | February 24, 2022: fix: correct indentation on documentation `#623 <https://github.com/mergeability/mergeable/pull/623>`_

--- a/docs/validators/commit.rst
+++ b/docs/validators/commit.rst
@@ -9,6 +9,7 @@ Commit
         message: 'Custom message' # Semantic release conventions must be followed
         skip_merge: true # Optional, Default is true. Will skip commit with message that includes 'Merge'
         oldest_only: false # Optional, Default is false. Only check the regex against the oldest commit
+        newest_only: false # Optional, Default is false. Only check the regex against the newest commit
         single_commit_only: false # Optional, Default is false. only process this validator if there is one commit
       jira:
         regex: '[A-Z][A-Z0-9]+-\d+'

--- a/lib/validators/commit.js
+++ b/lib/validators/commit.js
@@ -28,6 +28,7 @@ class Commit extends Validator {
         message: 'string',
         skip_merge: 'boolean',
         oldest_only: 'boolean',
+        newest_only: 'boolean',
         single_commit_only: 'boolean'
       }
     }
@@ -39,6 +40,7 @@ class Commit extends Validator {
 
     const messageSettings = validationSettings.message
     const oldestCommitOnly = _.isUndefined(messageSettings.oldest_only) ? false : messageSettings.oldest_only
+    const newestCommitOnly = _.isUndefined(messageSettings.newest_only) ? false : messageSettings.newest_only
     const skipMerge = _.isUndefined(messageSettings.skip_merge) ? true : messageSettings.skip_merge
     const singleCommitOnly = _.isUndefined(messageSettings.single_commit_only) ? false : messageSettings.single_commit_only
 
@@ -65,6 +67,10 @@ class Commit extends Validator {
 
     if (oldestCommitOnly) {
       orderedCommits = [orderedCommits[0]]
+    }
+
+    if (newestCommitOnly) {
+      orderedCommits = [orderedCommits[orderedCommits.length - 1]]
     }
 
     const commitMessages = orderedCommits.map(commit => commit.message)


### PR DESCRIPTION
Adding a newest_only boolean setting to commit validation as we require last commits to contain [patch|minor|major|no-version] for auto-versioning.