### PR TITLE
fix: supported events for `request_review` action

### DIFF
--- a/docs/actions/request_review.rst
+++ b/docs/actions/request_review.rst
@@ -12,4 +12,4 @@ You can request specific reviews from specific reviewers, teams, or both
 Supported Events:
 ::
 
-    'pull_request.*', 'issues.*'
+    'pull_request.*'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| August 20, 2022: fix: supported events for `request_review` action `#623 <https://github.com/mergeability/mergeable/pull/651>`
 | April 7, 2022: feat: Support adding deployment labels from values `#631 <https://github.com/mergeability/mergeable/pull/631>`_
 | March 22, 2022: fix: pass comment instance to removeErrorComments `#626 <https://github.com/mergeability/mergeable/pull/626>`_
 | February 24, 2022: fix: correct indentation on documentation `#623 <https://github.com/mergeability/mergeable/pull/623>`_


### PR DESCRIPTION
I noticed that the `request_review` in its class does not match the example provided in the documentation.