### PR TITLE
fix: set fallback value for `description` payload

### DIFF
--- a/__tests__/unit/validators/description.test.js
+++ b/__tests__/unit/validators/description.test.js
@@ -28,6 +28,12 @@ test('isMergeable is false if the PR body is empty', async () => {
   let descriptionValidation = await description.processValidate(createMockPR(''), settings)
   expect(descriptionValidation.status).toBe('fail')
 
+  descriptionValidation = await description.processValidate(createMockPR(undefined), settings)
+  expect(descriptionValidation.status).toBe('fail')
+
+  descriptionValidation = await description.processValidate(createMockPR(null), settings)
+  expect(descriptionValidation.status).toBe('fail')
+
   descriptionValidation = await description.processValidate(createMockPR('Some Description'), settings)
   expect(descriptionValidation.status).toBe('pass')
 })

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 CHANGELOG
 =====================================
-| August 20, 2022: fix: supported events for `request_review` action `#623 <https://github.com/mergeability/mergeable/pull/651>`_
+| August 25, 2022: fix: set fallback value for `description` payload `#655 <https://github.com/mergeability/mergeable/pull/655>`_
+| August 20, 2022: fix: supported events for `request_review` action `#651 <https://github.com/mergeability/mergeable/pull/651>`_
 | August 2, 2022: feat: Add newest_only commit validation setting `#649 <https://github.com/mergeability/mergeable/pull/649>`_
 | April 7, 2022: feat: Support adding deployment labels from values `#631 <https://github.com/mergeability/mergeable/pull/631>`_
 | March 22, 2022: fix: pass comment instance to removeErrorComments `#626 <https://github.com/mergeability/mergeable/pull/626>`_

--- a/lib/validators/description.js
+++ b/lib/validators/description.js
@@ -40,7 +40,7 @@ class Description extends Validator {
   }
 
   async validate (context, validationSettings) {
-    const description = this.getPayload(context).body
+    const description = this.getPayload(context).body || ''
 
     return this.processOptions(
       validationSettings,


### PR DESCRIPTION
In case, the payload `body` somehow returns undefined or null, we set the fallback value to an empty string.