### PR TITLE
fix: set fallback for `no_empty` options processor

### DIFF
--- a/__tests__/unit/validators/options_processor/options/no_empty.test.js
+++ b/__tests__/unit/validators/options_processor/options/no_empty.test.js
@@ -31,6 +31,8 @@ test('return pass if input meets the criteria', () => {
 
 test('return fail if input does not meet the criteria', () => {
   verify(true, '', [], 'fail')
+  verify(true, null, [], 'fail')
+  verify(true, undefined, [], 'fail')
   verify(false, '', [''], 'pass')
 })
 

--- a/__tests__/unit/validators/options_processor/options/no_empty.test.js
+++ b/__tests__/unit/validators/options_processor/options/no_empty.test.js
@@ -43,7 +43,7 @@ test('return error if input does not meet the criteria', () => {
     const config = noEmpty.process(validatorContext, input, rule)
     expect(config).toBeDefined()
   } catch (e) {
-    expect(e.message).toBe('Input type invalid, expected string as input')
+    expect(e.message).toBe('Input type invalid, expected string or Array as input')
   }
 
   input = [1]
@@ -51,7 +51,7 @@ test('return error if input does not meet the criteria', () => {
     const config = noEmpty.process(validatorContext, input, rule)
     expect(config).toBeDefined()
   } catch (e) {
-    expect(e.message).toBe('Input type invalid, expected string as input')
+    expect(e.message).toBe('Input type invalid, expected string or Array as input')
   }
 })
 

--- a/__tests__/unit/validators/options_processor/options/no_empty.test.js
+++ b/__tests__/unit/validators/options_processor/options/no_empty.test.js
@@ -36,6 +36,25 @@ test('return fail if input does not meet the criteria', () => {
   verify(false, '', [''], 'pass')
 })
 
+test('return error if input does not meet the criteria', () => {
+  const rule = { no_empty: { enabled: true } }
+  let input = 1
+  try {
+    const config = noEmpty.process(validatorContext, input, rule)
+    expect(config).toBeDefined()
+  } catch (e) {
+    expect(e.message).toBe('Input type invalid, expected string as input')
+  }
+
+  input = [1]
+  try {
+    const config = noEmpty.process(validatorContext, input, rule)
+    expect(config).toBeDefined()
+  } catch (e) {
+    expect(e.message).toBe('Input type invalid, expected string as input')
+  }
+})
+
 test('return error if inputs are not in expected format', async () => {
   const rule = { no_empty: { regex: true } }
   const input = 'the test'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| August 26, 2022: set fallback for `no_empty` options processor `#657 <https://github.com/mergeability/mergeable/pull/657>`_
 | August 25, 2022: fix: set fallback value for `description` payload `#655 <https://github.com/mergeability/mergeable/pull/655>`_
 | August 20, 2022: fix: supported events for `request_review` action `#651 <https://github.com/mergeability/mergeable/pull/651>`_
 | August 2, 2022: feat: Add newest_only commit validation setting `#649 <https://github.com/mergeability/mergeable/pull/649>`_

--- a/lib/validators/options_processor/options/no_empty.js
+++ b/lib/validators/options_processor/options/no_empty.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 
 const ENABLED_NOT_FOUND_ERROR = 'Failed to run the test because \'enabled\' is not provided for \'no_empty\' option. Please check README for more information about configuration'
-const UNKNOWN_INPUT_TYPE_ERROR = 'Input type invalid, expected string as input'
+const UNKNOWN_INPUT_TYPE_ERROR = 'Input type invalid, expected string or Array as input'
 
 class NoEmpty {
   static process (validatorContext, input, rule) {

--- a/lib/validators/options_processor/options/no_empty.js
+++ b/lib/validators/options_processor/options/no_empty.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 const ENABLED_NOT_FOUND_ERROR = 'Failed to run the test because \'enabled\' is not provided for \'no_empty\' option. Please check README for more information about configuration'
 const UNKNOWN_INPUT_TYPE_ERROR = 'Input type invalid, expected string as input'
 
@@ -18,7 +20,7 @@ class NoEmpty {
       }
     }
 
-    let isMergeable
+    let isMergeable = false
 
     const DEFAULT_SUCCESS_MESSAGE = `The ${validatorContext.name} is not empty`
     if (!description) description = `The ${validatorContext.name} can't be empty`
@@ -27,7 +29,7 @@ class NoEmpty {
       isMergeable = input.trim().length !== 0
     } else if (Array.isArray(input)) {
       isMergeable = input.length !== 0
-    } else {
+    } else if (!(input == null || _.isUndefined(input))) {
       throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
     }
 


### PR DESCRIPTION
This is to set fallback for `no_empty` options processor.