### PR TITLE
Fix grammar in output messages 

### DIFF
--- a/lib/configuration/lib/consts.js
+++ b/lib/configuration/lib/consts.js
@@ -7,7 +7,7 @@ module.exports = {
     status: 'success',
     payload: {
       title: 'Mergeable Run has been Completed!',
-      summary: 'All the validators have returned \'pass\'! \n Here are some stats of the run: \n {{validationCount}} validations were ran'
+      summary: 'All the validators have returned \'pass\'! \n Here are some stats of the run: \n {{validationCount}} validations were run'
     }
   }],
   DEFAULT_PR_FAIL: [{
@@ -19,7 +19,7 @@ module.exports = {
       summary: `### Status: {{toUpperCase validationStatus}}
 
         Here are some stats of the run:
-        {{validationCount}} validations were ran.
+        {{validationCount}} validations were run.
         {{passCount}} PASSED
         {{failCount}} FAILED
       `,
@@ -42,7 +42,7 @@ module.exports = {
       Some or All of the validators have returned 'error' status, please check below for details
       
       Here are some stats of the run: 
-      {{validationCount}} validations were ran. 
+      {{validationCount}} validations were run. 
       {{passCount}} ***PASSED***
       {{failCount}} ***FAILED***
       {{errorCount}} ***ERRORED***`,
@@ -62,7 +62,7 @@ Status {{toUpperCase status}}
   DEFAULT_ISSUES_PASS: [{
     do: 'comment',
     payload: {
-      body: 'All the validators have returned \'pass\'! \n Here are some stats of the run: \n {{validationCount}} validations were ran'
+      body: 'All the validators have returned \'pass\'! \n Here are some stats of the run: \n {{validationCount}} validations were run'
     }
   }],
   DEFAULT_ISSUES_FAIL: [{


### PR DESCRIPTION
fix a common, but subtle grammar mistake by converting 'were ran' into 'were run', see problem 1 on [this blog post](https://www.kirkmahoney.com/blog/2009/01/the-test-results-that-were-ran/) on 'were run' vs 'were ran'.