### PR TITLE
feat: Add team option to author filter

### DIFF
--- a/__tests__/unit/filters/author.test.js
+++ b/__tests__/unit/filters/author.test.js
@@ -1,15 +1,19 @@
 const Author = require('../../../lib/filters/author')
 const Helper = require('../../../__fixtures__/unit/helper')
+const Teams = require('../../../lib/validators/options_processor/teams')
+
+const authorName = 'mergeabletestauthorname'
+const otherAuthorName = 'someone-else'
 
 test('should fail with unexpected author', async () => {
   const author = new Author()
   const settings = {
     do: 'author',
     must_include: {
-      regex: 'someone-else'
+      regex: otherAuthorName
     }
   }
-  const filter = await author.processFilter(createMockContext('mergeable'), settings)
+  const filter = await author.processFilter(createMockContext(authorName), settings)
   expect(filter.status).toBe('fail')
 })
 
@@ -18,10 +22,10 @@ test('should pass with expected author', async () => {
   const settings = {
     do: 'author',
     must_include: {
-      regex: 'mergeable'
+      regex: authorName
     }
   }
-  const filter = await author.processFilter(createMockContext('mergeable'), settings)
+  const filter = await author.processFilter(createMockContext(authorName), settings)
   expect(filter.status).toBe('pass')
 })
 
@@ -30,10 +34,10 @@ test('should fail with excluded author', async () => {
   const settings = {
     do: 'author',
     must_exclude: {
-      regex: 'mergeable'
+      regex: authorName
     }
   }
-  const filter = await author.processFilter(createMockContext('mergeable'), settings)
+  const filter = await author.processFilter(createMockContext(authorName), settings)
   expect(filter.status).toBe('fail')
 })
 
@@ -42,11 +46,76 @@ test('should pass with excluded author', async () => {
   const settings = {
     do: 'author',
     must_exclude: {
-      regex: 'someone-else'
+      regex: otherAuthorName
     }
   }
-  const filter = await author.processFilter(createMockContext('mergeable'), settings)
+  const filter = await author.processFilter(createMockContext(authorName), settings)
   expect(filter.status).toBe('pass')
+})
+
+test('should pass with expected author from correct team', async () => {
+  const author = new Author()
+  const settings = {
+    do: 'author',
+    must_include: {
+      regex: authorName
+    },
+    team: 'org/team-slug'
+  }
+  Teams.extractTeamMemberships = jest.fn().mockReturnValue([authorName])
+  const filter = await author.processFilter(createMockContext(authorName), settings)
+  expect(filter.status).toBe('pass')
+})
+
+test('should fail with expected author from incorrect team', async () => {
+  const author = new Author()
+  const settings = {
+    do: 'author',
+    must_include: {
+      regex: authorName
+    },
+    team: 'org/team-slug'
+  }
+  Teams.extractTeamMemberships = jest.fn().mockReturnValue([])
+  const filter = await author.processFilter(createMockContext(authorName), settings)
+  expect(filter.status).toBe('fail')
+})
+
+test('should fail with unexpected author from correct team', async () => {
+  const author = new Author()
+  const settings = {
+    do: 'author',
+    must_include: {
+      regex: otherAuthorName
+    },
+    team: 'org/team-slug'
+  }
+  Teams.extractTeamMemberships = jest.fn().mockReturnValue([authorName])
+  const filter = await author.processFilter(createMockContext(authorName), settings)
+  expect(filter.status).toBe('fail')
+})
+
+test('should pass when the author is a member of the team', async () => {
+  const author = new Author()
+  const settings = {
+    do: 'author',
+    team: 'org/team-slug'
+  }
+  Teams.extractTeamMemberships = jest.fn().mockReturnValue([authorName])
+  const filter = await author.processFilter(createMockContext(authorName), settings)
+  expect(filter.status).toBe('pass')
+})
+
+test('should fail when the author is not a member of the team', async () => {
+  const author = new Author()
+  const authorName = 'mergeable'
+  const settings = {
+    do: 'author',
+    team: 'org/team-slug'
+  }
+  Teams.extractTeamMemberships = jest.fn().mockReturnValue([otherAuthorName])
+  const filter = await author.processFilter(createMockContext(authorName), settings)
+  expect(filter.status).toBe('fail')
 })
 
 const createMockContext = (author) => {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| February 03, 2023: feat: Add team option to author filter `#696 <https://github.com/mergeability/mergeable/pull/696>`_
 | February 3, 2023: feat: Add Not operator `#695 <https://github.com/mergeability/mergeable/pull/695>`_
 | September 28, 2022: feat: Add last comment validator `#668 <https://github.com/mergeability/mergeable/pull/668>`_
 | August 26, 2022: set fallback for `no_empty` options processor `#657 <https://github.com/mergeability/mergeable/pull/657>`_

--- a/docs/filters/author.rst
+++ b/docs/filters/author.rst
@@ -6,7 +6,11 @@ Author
       - do: author
         must_include:
             regex: 'user-1'
-            message: 'Custom message...'
+            message: 'Custom include message...'
+        must_exclude:
+            regex: 'user-2'
+            message: 'Custom exclude message...'
+        team: 'org/team-slug'  # verify that the author is in the team
         # all of the message sub-option is optional
 
 you can use ``and`` and ``or`` options to create more complex filters

--- a/lib/filters/author.js
+++ b/lib/filters/author.js
@@ -17,7 +17,8 @@ class Author extends Filter {
         regex: 'string',
         regex_flag: 'string',
         message: 'string'
-      }
+      },
+      team: 'string'
     }
   }
 

--- a/lib/filters/options_processor/options/team.js
+++ b/lib/filters/options_processor/options/team.js
@@ -1,0 +1,21 @@
+const Teams = require('../../../validators/options_processor/teams')
+
+class TeamProcessor {
+  static async process (context, filter, input, rule) {
+    const userName = input
+    const teamName = rule.team
+
+    const SUCCESS_MESSAGE = `'${userName}' is part of the '${teamName}' team'`
+    const FAILURE_MESSAGE = `'${userName}' is not part of the '${teamName}' team'`
+
+    const teamMemberships = await Teams.extractTeamMemberships(context, [teamName], [userName])
+    const isMember = teamMemberships.includes(userName)
+
+    return {
+      status: isMember ? 'pass' : 'fail',
+      description: isMember ? SUCCESS_MESSAGE : FAILURE_MESSAGE
+    }
+  }
+}
+
+module.exports = TeamProcessor


### PR DESCRIPTION
# Goal

Add a way to change behavior based on team membership.

This PR adds the `team` option to the `author` filter.
If the `team` is set, then it is verified that the `author` is part of the team, otherwise, the filter fails.

Together with #695, this enables checking whether an author is _not_ part of a team.

# How

I added `team: 'string'` to the supported settings of the author filter.
Then, I added a `TeamProcessor` that uses the existing functionality for `Teams` from the `validators` to check whether the user is part of the team.
