### PR TITLE
chore: Update node version for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.17.6]
+        node-version: [18.14.1]
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| February 3, 2023: chore: Update node version for release workflow `#699 <https://github.com/mergeability/mergeable/pull/699>`_
 | February 3, 2023: feat: Add Not operator `#695 <https://github.com/mergeability/mergeable/pull/695>`_
 | September 28, 2022: feat: Add last comment validator `#668 <https://github.com/mergeability/mergeable/pull/668>`_
 | August 26, 2022: set fallback for `no_empty` options processor `#657 <https://github.com/mergeability/mergeable/pull/657>`_


### PR DESCRIPTION
[The latest release on `master` failed due to the `semantic-release` action no longer supporting the `node` version that was used](https://github.com/mergeability/mergeable/actions/runs/4223903147/jobs/7334181167):
> [semantic-release]: node version >=18 is required. Found v14.17.6.
> 
> See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details 
> Error: Process completed with exit code 1.

Thus, I updated the version to Node `18.12.0`, the latest released LTS version (see also [nodejs releases](https://nodejs.org/es/blog/release/))