### PR TITLE
fix: Extend checks supported events

### DIFF
--- a/docs/actions/check.rst
+++ b/docs/actions/check.rst
@@ -69,6 +69,9 @@ You can pass in Handlebars template to show the details result of the run.
     checks will automatically re-run if the base branch has a modified config file
 
 Supported Events:
+
+The `pull_request.closed` event is not supported since it does not have meaningful use in the context of GitHub check API.
+
 ::
 
-    'pull_request.*', 'pull_request_review.*'
+    'pull_request.assigned', 'pull_request.auto_merge_disabled', 'pull_request.auto_merge_enabled', 'pull_request.converted_to_draft', 'pull_request.demilestoned', 'pull_request.dequeued', 'pull_request.edited', 'pull_request.enqueued', 'pull_request.labeled', 'pull_request.locked', 'pull_request.milestoned', 'pull_request.opened', 'pull_request.push_synchronize', 'pull_request.ready_for_review', 'pull_request.reopened', 'pull_request.review_request_removed', 'pull_request.review_requested', 'pull_request.synchronize', 'pull_request.unassigned', 'pull_request.unlabeled', 'pull_request.unlocked', 'pull_request_review.dismissed', 'pull_request_review.edited', 'pull_request_review.submitted'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| February 27, 2023: fix: Extend checks supported events `#700 <https://github.com/mergeability/mergeable/pull/700>`_
 | February 03, 2023: feat: Add team option to author filter `#696 <https://github.com/mergeability/mergeable/pull/696>`_
 | February 3, 2023: chore: Update node version for release workflow `#699 <https://github.com/mergeability/mergeable/pull/699>`_
 | February 3, 2023: feat: Add Not operator `#695 <https://github.com/mergeability/mergeable/pull/695>`_

--- a/lib/actions/checks.js
+++ b/lib/actions/checks.js
@@ -63,20 +63,36 @@ const updateParams = ({ context, id, name, status, output, conclusion }) => {
 class Checks extends Action {
   constructor () {
     super('checks')
+
+    // Support for 'pull_request.closed' event was not enabled since
+    // it does not have meaningful use in the context of GitHub
+    // check API: there is no reason to post a check result on a
+    // pull request that is actually closed.
     this.supportedEvents = [
-      'pull_request.opened',
-      'pull_request.edited',
-      'pull_request_review.submitted',
-      'pull_request_review.edited',
-      'pull_request_review.dismissed',
-      'pull_request.labeled',
-      'pull_request.milestoned',
-      'pull_request.demilestoned',
       'pull_request.assigned',
+      'pull_request.auto_merge_disabled',
+      'pull_request.auto_merge_enabled',
+      'pull_request.converted_to_draft',
+      'pull_request.demilestoned',
+      'pull_request.dequeued',
+      'pull_request.edited',
+      'pull_request.enqueued',
+      'pull_request.labeled',
+      'pull_request.locked',
+      'pull_request.milestoned',
+      'pull_request.opened',
+      'pull_request.push_synchronize',
+      'pull_request.ready_for_review',
+      'pull_request.reopened',
+      'pull_request.review_request_removed',
+      'pull_request.review_requested',
+      'pull_request.synchronize',
       'pull_request.unassigned',
       'pull_request.unlabeled',
-      'pull_request.synchronize',
-      'pull_request.push_synchronize'
+      'pull_request.unlocked',
+      'pull_request_review.dismissed',
+      'pull_request_review.edited',
+      'pull_request_review.submitted'
     ]
     this.checkRunResult = new Map()
   }


### PR DESCRIPTION
The checks action should be able to support every
pull_request and pull_request_review events like stated
in the documentation. For example support for some events
like pull_request.ready_for_review was not supported with
current implementation.