### PR TITLE
fix: embellished docs on checks

### DIFF
--- a/docs/actions/check.rst
+++ b/docs/actions/check.rst
@@ -3,10 +3,15 @@ Check
 
 .. note::
     The logic for whether checks will be added by default is as follows:
-    1. If no action is provided in either pass, fail or error , add `checks` as default (to be backward compatible)
-    2. If only actions other than `checks` is provided, don't add check as default (to support cases where checks are not wanted)
-    3. If checks is a part of the actions provided, all pass , fail and error cases will have `checks` (to prevent case where a check is hanged and never finish processing)
+    1. If no action is provided in either pass, fail or error, add ``checks`` as default (to be backward compatible)
 
+    2. If only actions other than ``checks`` is provided, don't add check as default (to support cases where checks are not wanted)
+
+    3. If checks is a part of the actions provided, all pass, fail and error cases will have `checks` (to prevent case where a check is hanged and never finish processing)
+::
+
+.. warning::
+    Failing to add ``checks`` when no other action is provided (see point 1. above) will result in the checks not being executed. You must explicitly add them as a default.
 ::
 
     - do: checks # default pass case


### PR DESCRIPTION
There is some key information on the checks page which is not as obvious as I would expect. If one doesn't add the `checks` as a default action then mergeable will complete but fail to obviously run the checks.