### PR TITLE
fix: search and replace of special annotations

### DIFF
--- a/__tests__/unit/actions/lib/searchAndReplaceSpecialAnnotation.test.js
+++ b/__tests__/unit/actions/lib/searchAndReplaceSpecialAnnotation.test.js
@@ -36,4 +36,22 @@ describe('searchAndReplaceSpecialAnnotations', () => {
     }
     expect(searchAndReplaceSpecialAnnotations('this is @author', payload)).toBe('this is creator')
   })
+
+  test('@@author is replaced by @payload.user.login', () => {
+    const payload = {
+      user: {
+        login: 'creator'
+      }
+    }
+    expect(searchAndReplaceSpecialAnnotations('this is @@author', payload)).toBe('this is @creator')
+  })
+
+  test('replaces annotation anywhere in the text', () => {
+    const payload = {
+      user: {
+        login: 'creator'
+      }
+    }
+    expect(searchAndReplaceSpecialAnnotations('this is something@author speaking', payload)).toBe('this is somethingcreator speaking')
+  })
 })

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| Feb 27, 2024: fix: search and replace of special annotations `#735 https://github.com/mergeability/mergeable/pull/735`_
 | May 12, 2023: fix: Loading teams for team option of author filter/validator `#713 <https://github.com/mergeability/mergeable/pull/713>`_
 | May 11, 2023: fix: Send correct payload for changing labels `#715 <https://github.com/mergeability/mergeable/pull/715>`_
 | April 25, 2023: feat: Add author validator `#710 <https://github.com/mergeability/mergeable/pull/710>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,6 @@
 CHANGELOG
 =====================================
-| Feb 27, 2024: fix: search and replace of special annotations `#735 https://github.com/mergeability/mergeable/pull/735`_
+| Feb 27, 2024: fix: search and replace of special annotations `#735 <https://github.com/mergeability/mergeable/pull/735>`_
 | May 12, 2023: fix: Loading teams for team option of author filter/validator `#713 <https://github.com/mergeability/mergeable/pull/713>`_
 | May 11, 2023: fix: Send correct payload for changing labels `#715 <https://github.com/mergeability/mergeable/pull/715>`_
 | April 25, 2023: feat: Add author validator `#710 <https://github.com/mergeability/mergeable/pull/710>`_

--- a/lib/actions/lib/searchAndReplaceSpecialAnnotation.js
+++ b/lib/actions/lib/searchAndReplaceSpecialAnnotation.js
@@ -6,11 +6,11 @@ const searchAndReplaceSpecialAnnotations = (template, payload) => {
   let newTemplate = template
 
   for (const annotation of Object.keys(SPECIAL_ANNOTATION)) {
-    const specialAnnotationRegex = new RegExp(`([^\\\\])${annotation}`)
+    const specialAnnotationRegex = new RegExp(`(?<!\\\\)${annotation}`)
     const annotationAtStartRegex = new RegExp(`^${annotation}`)
     const escapeAnnotationRegex = new RegExp(`(\\\\){1}${annotation}`)
 
-    newTemplate = newTemplate.replace(specialAnnotationRegex, ` ${SPECIAL_ANNOTATION[annotation](payload)}`)
+    newTemplate = newTemplate.replace(specialAnnotationRegex, `${SPECIAL_ANNOTATION[annotation](payload)}`)
     newTemplate = newTemplate.replace(escapeAnnotationRegex, annotation)
     newTemplate = newTemplate.replace(annotationAtStartRegex, SPECIAL_ANNOTATION[annotation](payload))
   }


### PR DESCRIPTION
### Current Problem

There isn't a way to tag authors as the annotation `@@author` is replaced by ` author`.

```js
expect(searchAndReplaceSpecialAnnotations('this is @@author', payload)).toBe('this is @creator')

    Expected: "this is @creator"
    Received: "this is  creator"
```

```js
expect(searchAndReplaceSpecialAnnotations('this is something@author', payload)).toBe('this is somethingcreator')

    Expected: "this is somethingcreator"
    Received: "this is somethin creator"
```

### Solution

Use a negative lookbehind `?<!\\\\${annotation}` to not match escaped annotations. The previous regex used to match any character before `@author` and would replace it with " author".

I have also added a couple of new tests to test the search and replace functionality.