### PR TITLE
chore: fix typo "were ran" vs "were run" typo

### DIFF
--- a/__tests__/e2e/smoke.test.js
+++ b/__tests__/e2e/smoke.test.js
@@ -72,7 +72,7 @@ mergeable:
       {
         title: '1/1 Fail(s):  TITLE',
         summary:
-            '### Status: FAIL\n\n        Here are some stats of the run:\n        1 validations were ran.\n        0 PASSED\n        1 FAILED\n      ',
+            '### Status: FAIL\n\n        Here are some stats of the run:\n        1 validations were run.\n        0 PASSED\n        1 FAILED\n      ',
         text:
           '#### :x: Validator: TITLE\n * :heavy_check_mark: ***title must exclude \'must_be_excluded_text\'***\n       Input : [WIP] Test3\n       Settings : ```{"must_exclude":{"regex":"must_be_excluded_text"}}```\n * :x: ***title does not include "must_be_included_text"***\n       Input : [WIP] Test3\n       Settings : ```{"must_include":{"regex":"must_be_included_text"}}```\n * :x: ***title must begins with "begins_with_text"***\n       Input : [WIP] Test3\n       Settings : ```{"begins_with":{"match":"begins_with_text"}}```\n * :x: ***title must end with "ends_with_text"***\n       Input : [WIP] Test3\n       Settings : ```{"ends_with":{"match":"ends_with_text"}}```\n * :x: ***(title must begins with "begins_with_text"  ***AND***  title must end with "ends_with_text")***\n       Input : [WIP] Test3\n       Settings : ```{"and":[{"begins_with":{"match":"begins_with_text"}},{"ends_with":{"match":"ends_with_text"}}]}```\n * :x: ***(title does not include "must_be_included_text"  ***OR***  title must begins with "begins_with_text")***\n       Input : [WIP] Test3\n       Settings : ```{"or":[{"must_include":{"regex":"must_be_included_text"}},{"begins_with":{"match":"begins_with_text"}}]}```\n<!-- #mergeable-data {"id":4,"eventName":"pull_request","action":"edited"} #mergeable-data -->'
       },

--- a/docs/actions/check.rst
+++ b/docs/actions/check.rst
@@ -13,7 +13,7 @@ Check
       status: 'success' # Can be: success, failure, neutral, cancelled, timed_out, or action_required
       payload:
         title: 'Mergeable Run have been Completed!'
-        summary: "All the validators have returned 'pass'! \n Here are some stats of the run: \n {{validationCount}} validations were ran"
+        summary: "All the validators have returned 'pass'! \n Here are some stats of the run: \n {{validationCount}} validations were run"
 
 You can pass in Handlebars template to show the details result of the run.
 
@@ -26,7 +26,7 @@ You can pass in Handlebars template to show the details result of the run.
         summary: |
              ### Status: {{toUpperCase validationStatus}}
                   Here are some stats of the run:
-                  {{validationCount}} validations were ran.
+                  {{validationCount}} validations were run.
                   {{passCount}} PASSED
                   {{failCount}} FAILED
         text: "{{#each validationSuites}}\n
@@ -46,7 +46,7 @@ You can pass in Handlebars template to show the details result of the run.
         summary: |
             ### Status: {{toUpperCase validationStatus}}
             Some or All of the validators have returned 'error' status, please check below for details
-            Here are some stats of the run: \n {{validationCount}} validations were ran.
+            Here are some stats of the run: \n {{validationCount}} validations were run.
             {{passCount}} ***PASSED***
             {{failCount}} ***FAILED***
             {{errorCount}} ***ERRORED***

--- a/lib/configuration/lib/consts.js
+++ b/lib/configuration/lib/consts.js
@@ -7,7 +7,7 @@ module.exports = {
     status: 'success',
     payload: {
       title: 'Mergeable Run has been Completed!',
-      summary: 'All the validators have returned \'pass\'! \n Here are some stats of the run: \n {{validationCount}} validations were ran'
+      summary: 'All the validators have returned \'pass\'! \n Here are some stats of the run: \n {{validationCount}} validations were run'
     }
   }],
   DEFAULT_PR_FAIL: [{
@@ -19,7 +19,7 @@ module.exports = {
       summary: `### Status: {{toUpperCase validationStatus}}
 
         Here are some stats of the run:
-        {{validationCount}} validations were ran.
+        {{validationCount}} validations were run.
         {{passCount}} PASSED
         {{failCount}} FAILED
       `,
@@ -42,7 +42,7 @@ module.exports = {
       Some or All of the validators have returned 'error' status, please check below for details
       
       Here are some stats of the run: 
-      {{validationCount}} validations were ran. 
+      {{validationCount}} validations were run. 
       {{passCount}} ***PASSED***
       {{failCount}} ***FAILED***
       {{errorCount}} ***ERRORED***`,
@@ -62,7 +62,7 @@ Status {{toUpperCase status}}
   DEFAULT_ISSUES_PASS: [{
     do: 'comment',
     payload: {
-      body: 'All the validators have returned \'pass\'! \n Here are some stats of the run: \n {{validationCount}} validations were ran'
+      body: 'All the validators have returned \'pass\'! \n Here are some stats of the run: \n {{validationCount}} validations were run'
     }
   }],
   DEFAULT_ISSUES_FAIL: [{


### PR DESCRIPTION
This PR is based on this previous PR (https://github.com/mergeability/mergeable/pull/689). If this PR is merged, #689 could be closed because this contains the previous PR.

Following the same [blog post](https://www.kirkmahoney.com/blog/2009/01/the-test-results-that-were-ran/).

This PR includes:

- Typo fix
- Documentation fix
- Test E2E fix to match the typo.