### PR TITLE
chore: bump node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:20
 
 WORKDIR /app
 


### PR DESCRIPTION
Node 20 is required to run mergeable after https://github.com/mergeability/mergeable/pull/738