### PR TITLE
fix: Docker image not working

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,38 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
 npm-debug.log
 *.pem
 .env
 coverage
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: ${{ github.repository }}
+  REGISTRY_IMAGE: ${{ github.repository_owner }}-${{ github.repository }}
 
 jobs:
   build:
@@ -29,6 +29,12 @@ jobs:
       
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Lowercase REGISTRY_IMAGE for docker image naming convention
+        run: |
+          echo "OWNER_LC=${REGISTRY_IMAGE,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
       
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: ch4s3r/mergeable
+  REGISTRY_IMAGE: mergeability/mergeable
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: ${{ github.repository_owner }}-${{ github.repository }}
+  REGISTRY_IMAGE: ${{ github.repository }}
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: mergeability/mergeable
+  REGISTRY_IMAGE: ch4s3r/mergeable
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: ${{ github.repository_owner }}/${{ github.repository }}
+  REGISTRY_IMAGE: ${{ github.repository }}
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: ch4s3r/mergeable
+  REGISTRY_IMAGE: ${{ github.repository_owner }}/${{ github.repository }}
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Lowercase REGISTRY_IMAGE for docker image naming convention
         run: |
-          echo "OWNER_LC=${REGISTRY_IMAGE,,}" >>${GITHUB_ENV}
+          echo "REGISTRY_IMAGE=${REGISTRY_IMAGE,,}" >> $GITHUB_ENV
         env:
           OWNER: '${{ github.repository_owner }}'
       

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_IMAGE: ${{ github.repository }}
+  REGISTRY_IMAGE: ch4s3r/mergeable
 
 jobs:
   build:
@@ -29,12 +29,6 @@ jobs:
       
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Lowercase REGISTRY_IMAGE for docker image naming convention
-        run: |
-          echo "REGISTRY_IMAGE=${REGISTRY_IMAGE,,}" >> $GITHUB_ENV
-        env:
-          REGISTRY_IMAGE: ${{ env.REGISTRY_IMAGE }}
       
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "REGISTRY_IMAGE=${REGISTRY_IMAGE,,}" >> $GITHUB_ENV
         env:
-          OWNER: '${{ github.repository_owner }}'
+          REGISTRY_IMAGE: ${{ env.REGISTRY_IMAGE }}
       
       - name: Docker meta
         id: meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,38 @@
-FROM node:16
+# syntax=docker/dockerfile:1
 
-WORKDIR /app
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
 
-COPY package*.json ./
-RUN npm ci --only=production
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
+ARG NODE_VERSION=18
+
+FROM node:${NODE_VERSION}-alpine
+
+# Use production node environment by default.
+ENV NODE_ENV production
+
+
+WORKDIR /usr/src/app
+
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /root/.npm to speed up subsequent builds.
+# Leverage a bind mounts to package.json and package-lock.json to avoid having to copy them into
+# into this layer.
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=package-lock.json,target=package-lock.json \
+    --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev
+
+# Run the application as a non-root user.
+USER node
+
+# Copy the rest of the source files into the image.
 COPY . .
 
-ENV PORT=${PORT:-3000}
-USER 1000:1000
+# Expose the port that the application listens on.
+EXPOSE 3000
 
-CMD ./node_modules/probot/bin/probot.js run --port $PORT ./index.js
+# Run the application.
+CMD npm start

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,51 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker Compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# Here the instructions define your application as a service called "server".
+# This service is built from the Dockerfile in the current directory.
+# You can add other services your application may depend on here, such as a
+# database or a cache. For examples, see the Awesome Compose repository:
+# https://github.com/docker/awesome-compose
+services:
+  server:
+    build:
+      context: .
+    environment:
+      NODE_ENV: production
+    ports:
+      - 3000:3000
+
+# The commented out section below is an example of how to define a PostgreSQL
+# database that your application can use. `depends_on` tells Docker Compose to
+# start the database before your application. The `db-data` volume persists the
+# database data between container restarts. The `db-password` secret is used
+# to set the database password. You must create `db/password.txt` and add
+# a password of your choosing to it before running `docker-compose up`.
+#     depends_on:
+#       db:
+#         condition: service_healthy
+#   db:
+#     image: postgres
+#     restart: always
+#     user: postgres
+#     secrets:
+#       - db-password
+#     volumes:
+#       - db-data:/var/lib/postgresql/data
+#     environment:
+#       - POSTGRES_DB=example
+#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+#     expose:
+#       - 5432
+#     healthcheck:
+#       test: [ "CMD", "pg_isready" ]
+#       interval: 10s
+#       timeout: 5s
+#       retries: 5
+# volumes:
+#   db-data:
+# secrets:
+#   db-password:
+#     file: db/password.txt
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,7 @@
 CHANGELOG
 =====================================
+| June 10, 2024: fix: Docker image not working `#753 <https://github.com/mergeability/mergeable/pull/753>`_
+| June 10, 2024: feat: publish multi arch docker image to dockerhub `#751 <https://github.com/mergeability/mergeable/pull/751>`_
 | April 29, 2024: fix: Always allow assigning author  `#744 <https://github.com/mergeability/mergeable/pull/744>`_
 | Mar 11, 2024: fix: bump dependencies probot, jest and nock to latest versions and update ci workflow to use node 20 `#738 <https://github.com/mergeability/mergeable/pull/738>`_ 
 | Feb 27, 2024: fix: search and replace of special annotations `#735 <https://github.com/mergeability/mergeable/pull/735>`_


### PR DESCRIPTION
The old `Dockerfile` was using nodejs version 16 and not building at all.
This PR adds a new setup created with `docker init`.
It uses node 18 now as stated in the `package.json`.

These versions need to be kept in sync, so updating the nodejs version must also happen in the `Dockerfile`.

Executing the new docker image works:

![image](https://github.com/mergeability/mergeable/assets/2782710/f919669c-3e55-4f87-98b6-a437fbf35425)
