### PR TITLE
feat: Support 'issue_comment' event as trigger for actions

### DIFF
--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -182,7 +182,7 @@ module.exports = {
           },
           requestReviewers: jest.fn().mockReturnValue(options.requestReviewers || 'request review success'),
           merge: jest.fn().mockReturnValue(options.merge || 'merged'),
-          get: jest.fn()
+          get: jest.fn().mockReturnValue({ data: { head: { ref: 'test', sha: 'sha1' } } })
         },
         paginate: jest.fn(async (fn, cb) => {
           return fn.then(cb)

--- a/__tests__/unit/actions/assign.test.js
+++ b/__tests__/unit/actions/assign.test.js
@@ -1,15 +1,32 @@
 const Assign = require('../../../lib/actions/assign')
 const Helper = require('../../../__fixtures__/unit/helper')
 
+test.each([
+  undefined,
+  'pull_request',
+  'issues',
+  'issue_comment'
+])('check that assign is called for %s events', async (eventName) => {
+  const settings = {
+    assignees: []
+  }
+
+  const assign = new Assign()
+  const context = createMockContext(eventName)
+
+  await assign.afterValidate(context, settings)
+  expect(context.octokit.issues.addAssignees.mock.calls.length).toBe(1)
+})
+
 test('check that assignees are added when afterValidate is called with proper parameter', async () => {
   const settings = {
     assignees: ['testuser1', 'testuser2']
   }
 
-  const comment = new Assign()
+  const assign = new Assign()
   const context = createMockContext()
 
-  await comment.afterValidate(context, settings)
+  await assign.afterValidate(context, settings)
   expect(context.octokit.issues.addAssignees.mock.calls.length).toBe(1)
   expect(context.octokit.issues.addAssignees.mock.calls[0][0].assignees[0]).toBe('testuser1')
   expect(context.octokit.issues.addAssignees.mock.calls[0][0].assignees[1]).toBe('testuser2')
@@ -20,10 +37,10 @@ test('check that creator is added when assignee is @author', async () => {
     assignees: ['@author']
   }
 
-  const comment = new Assign()
+  const assign = new Assign()
   const context = createMockContext()
 
-  await comment.afterValidate(context, settings)
+  await assign.afterValidate(context, settings)
   expect(context.octokit.issues.addAssignees.mock.calls.length).toBe(1)
   expect(context.octokit.issues.addAssignees.mock.calls[0][0].assignees[0]).toBe('creator')
 })
@@ -33,7 +50,7 @@ test('check only authorized users are added as assignee ', async () => {
     assignees: ['testuser1', 'testuser2']
   }
 
-  const comment = new Assign()
+  const assign = new Assign()
   const context = createMockContext()
 
   context.octokit.issues.checkUserCanBeAssigned = (input) => {
@@ -45,14 +62,14 @@ test('check only authorized users are added as assignee ', async () => {
     })
   }
 
-  await comment.afterValidate(context, settings)
+  await assign.afterValidate(context, settings)
   expect(context.octokit.issues.addAssignees.mock.calls.length).toBe(1)
   expect(context.octokit.issues.addAssignees.mock.calls[0][0].assignees[0]).toBe('testuser1')
   expect(context.octokit.issues.addAssignees.mock.calls[0][0].assignees[1]).toBeUndefined()
 })
 
-const createMockContext = () => {
-  const context = Helper.mockContext()
+const createMockContext = (eventName = undefined) => {
+  const context = Helper.mockContext({ eventName })
 
   context.octokit.issues.addAssignees = jest.fn()
   return context

--- a/__tests__/unit/actions/close.test.js
+++ b/__tests__/unit/actions/close.test.js
@@ -1,6 +1,28 @@
 const Close = require('../../../lib/actions/close')
 const Helper = require('../../../__fixtures__/unit/helper')
 
+test.each([
+  undefined,
+  'pull_request',
+  'issues',
+  'issue_comment',
+  'schedule'
+])('check that close is called for %s events', async (eventName) => {
+  const close = new Close()
+  const context = Helper.mockContext({ eventName: eventName })
+  const schedulerResult = {
+    validationSuites: [{
+      schedule: {
+        issues: [{ number: 1, user: { login: 'scheduler' } }],
+        pulls: []
+      }
+    }]
+  }
+
+  await close.afterValidate(context, {}, '', schedulerResult)
+  expect(context.octokit.issues.update.mock.calls.length).toBe(1)
+})
+
 test('check that issue is closed', async () => {
   const close = new Close()
   const context = Helper.mockContext()

--- a/__tests__/unit/actions/labels.test.js
+++ b/__tests__/unit/actions/labels.test.js
@@ -2,6 +2,31 @@ const Labels = require('../../../lib/actions/labels')
 const Helper = require('../../../__fixtures__/unit/helper')
 const UnSupportedSettingError = require('../../../lib/errors/unSupportedSettingError')
 
+test.each([
+  undefined,
+  'pull_request',
+  'issues',
+  'issue_comment',
+  'schedule'
+])('check that close is called for %s events', async (eventName) => {
+  const labels = new Labels()
+  const context = createMockContext([], eventName)
+  const settings = {
+    add: ['a label']
+  }
+  const schedulerResult = {
+    validationSuites: [{
+      schedule: {
+        issues: [{ number: 1, user: { login: 'scheduler' } }],
+        pulls: []
+      }
+    }]
+  }
+
+  await labels.afterValidate(context, settings, '', schedulerResult)
+  expect(context.octokit.issues.setLabels.mock.calls.length).toBe(1)
+})
+
 test('check that replace replaces existing labels', async () => {
   const labels = new Labels()
   const context = createMockContext(['drop_label'])

--- a/__tests__/unit/configuration/transformers/v2Config.test.js
+++ b/__tests__/unit/configuration/transformers/v2Config.test.js
@@ -92,6 +92,42 @@ test('pass, fail, error defaults will load when pull_request is mixed with other
   expect(transformed.mergeable[0].error).toEqual(constants.DEFAULT_PR_ERROR)
 })
 
+test('pass, fail, error defaults will load when issue_comment event is specified.', () => {
+  const config = `
+  version: 2
+  mergeable:
+    - when: issue_comment.*
+      validate:
+        - do: lastComment
+          must_exclude:
+            regex: 'wip|work in progress'
+  `
+  const transformed = V2Config.transform(yaml.safeLoad(config))
+
+  expect(transformed.mergeable[0].pass).toEqual(constants.DEFAULT_PR_PASS)
+  expect(transformed.mergeable[0].fail).toEqual(constants.DEFAULT_PR_FAIL)
+  expect(transformed.mergeable[0].error).toEqual(constants.DEFAULT_PR_ERROR)
+})
+
+test('pass, fail, error defaults will load when pull_request_review event is specified.', () => {
+  const config = `
+  version: 2
+  mergeable:
+    - when: pull_request_review.*
+      validate:
+        - do: payload
+          review:
+            state:
+              must_exclude:
+                regex: 'changes_requested'
+  `
+  const transformed = V2Config.transform(yaml.safeLoad(config))
+
+  expect(transformed.mergeable[0].pass).toEqual(constants.DEFAULT_PR_PASS)
+  expect(transformed.mergeable[0].fail).toEqual(constants.DEFAULT_PR_FAIL)
+  expect(transformed.mergeable[0].error).toEqual(constants.DEFAULT_PR_ERROR)
+})
+
 test('only pass, fail defaults ignore recipes that are not for pull_requests', () => {
   const config = `
   version: 2

--- a/docs/actions/assign.rst
+++ b/docs/actions/assign.rst
@@ -1,6 +1,8 @@
 Assign
 ^^^^^^^^
 
+You can assign specific people to a pull request or issue.
+
 ::
 
     - do: assign
@@ -9,4 +11,4 @@ Assign
 Supported Events:
 ::
 
-    'pull_request.*', 'issues.*'
+    'pull_request.*', 'issues.*', 'issue_comment.*'

--- a/docs/actions/checks.rst
+++ b/docs/actions/checks.rst
@@ -1,5 +1,7 @@
-Check
+Checks
 ^^^^^^^^
+
+You can add check runs to a pull request to enforce that it can only be merged once all checks returned with success.
 
 .. note::
     The logic for whether checks will be added by default is as follows:
@@ -74,4 +76,4 @@ The `pull_request.closed` event is not supported since it does not have meaningf
 
 ::
 
-    'pull_request.assigned', 'pull_request.auto_merge_disabled', 'pull_request.auto_merge_enabled', 'pull_request.converted_to_draft', 'pull_request.demilestoned', 'pull_request.dequeued', 'pull_request.edited', 'pull_request.enqueued', 'pull_request.labeled', 'pull_request.locked', 'pull_request.milestoned', 'pull_request.opened', 'pull_request.push_synchronize', 'pull_request.ready_for_review', 'pull_request.reopened', 'pull_request.review_request_removed', 'pull_request.review_requested', 'pull_request.synchronize', 'pull_request.unassigned', 'pull_request.unlabeled', 'pull_request.unlocked', 'pull_request_review.dismissed', 'pull_request_review.edited', 'pull_request_review.submitted'
+    'pull_request.assigned', 'pull_request.auto_merge_disabled', 'pull_request.auto_merge_enabled', 'pull_request.converted_to_draft', 'pull_request.demilestoned', 'pull_request.dequeued', 'pull_request.edited', 'pull_request.enqueued', 'pull_request.labeled', 'pull_request.locked', 'pull_request.milestoned', 'pull_request.opened', 'pull_request.push_synchronize', 'pull_request.ready_for_review', 'pull_request.reopened', 'pull_request.review_request_removed', 'pull_request.review_requested', 'pull_request.synchronize', 'pull_request.unassigned', 'pull_request.unlabeled', 'pull_request.unlocked', 'pull_request_review.dismissed', 'pull_request_review.edited', 'pull_request_review.submitted', 'issue_comment.*'

--- a/docs/actions/close.rst
+++ b/docs/actions/close.rst
@@ -1,6 +1,8 @@
 Close
 ^^^^^^^^
 
+You can close a pull request or issue.
+
 ::
 
     - do: close
@@ -8,4 +10,4 @@ Close
 Supported Events:
 ::
 
-    'schedule.repository', 'pull_request.*', 'issues.*'
+    'schedule.repository', 'pull_request.*', 'issues.*', 'issue_comment.*'

--- a/docs/actions/comment.rst
+++ b/docs/actions/comment.rst
@@ -1,6 +1,8 @@
 Comment
 ^^^^^^^^
 
+You can add a comment to a pull request or issue.
+
 ::
 
     - do: comment
@@ -12,4 +14,4 @@ Comment
 Supported Events:
 ::
 
-    'schedule.repository', 'pull_request.*', 'issues.*'
+    'schedule.repository', 'pull_request.*', 'issues.*', 'issue_comment.*'

--- a/docs/actions/labels.rst
+++ b/docs/actions/labels.rst
@@ -83,4 +83,4 @@ Note that the glob functionality is powered by the minimatch library. Please see
 Supported Events:
 ::
 
-    'schedule.repository', 'pull_request.*', 'issues.*'
+    'schedule.repository', 'pull_request.*', 'issues.*', 'issue_comment.*'

--- a/docs/actions/merge.rst
+++ b/docs/actions/merge.rst
@@ -1,6 +1,8 @@
 Merge
 ^^^^^^^^
 
+You can merge a pull request and specify the merge method used.
+
 ::
 
     - do: merge
@@ -14,4 +16,4 @@ Merge
 Supported Events:
 ::
 
-    'pull_request.*', 'pull_request_review.*', 'status.*', 'check_suite.*'
+    'pull_request.*', 'pull_request_review.*', 'status.*', 'check_suite.*', 'issue_comment.*'

--- a/docs/actions/request_review.rst
+++ b/docs/actions/request_review.rst
@@ -1,7 +1,7 @@
 Request Review
 ^^^^^^^^^^^^^^^
 
-You can request specific reviews from specific reviewers, teams, or both
+You can request specific reviews from specific reviewers, teams, or both for a pull request.
 
 ::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| June 12, 2024: feat: Support `issue_comment` event as trigger for actions `#754 <https://github.com/mergeability/mergeable/pull/754>`_
 | June 10, 2024: fix: Docker image not working `#753 <https://github.com/mergeability/mergeable/pull/753>`_
 | June 10, 2024: feat: publish multi arch docker image to dockerhub `#751 <https://github.com/mergeability/mergeable/pull/751>`_
 | April 29, 2024: fix: Always allow assigning author  `#744 <https://github.com/mergeability/mergeable/pull/744>`_

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -174,7 +174,7 @@ Actions that mergeable is currently able to perform.
 
 .. toctree::
     actions/assign.rst
-    actions/check.rst
+    actions/checks.rst
     actions/close.rst
     actions/comment.rst
     actions/merge.rst

--- a/lib/actions/assign.js
+++ b/lib/actions/assign.js
@@ -6,7 +6,8 @@ class Assign extends Action {
     super('assign')
     this.supportedEvents = [
       'pull_request.*',
-      'issues.*'
+      'issues.*',
+      'issue_comment.*'
     ]
   }
 

--- a/lib/actions/checks.js
+++ b/lib/actions/checks.js
@@ -15,6 +15,11 @@ const createChecks = async (context, payload, actionObj) => {
   if (context.payload.checksuite) {
     params.head_branch = context.payload.checksuite.head_branch
     params.head_sha = context.payload.checksuite.head_sha
+  } else if (context.eventName === 'issue_comment') {
+    const issueNumber = context.payload.issue.number
+    const pullRequest = (await actionObj.githubAPI.getPR(context, issueNumber)).data
+    params.head_branch = pullRequest.head.ref
+    params.head_sha = pullRequest.head.sha
   } else {
     params.head_branch = context.payload.pull_request.head.ref
     params.head_sha = context.payload.pull_request.head.sha
@@ -92,7 +97,8 @@ class Checks extends Action {
       'pull_request.unlocked',
       'pull_request_review.dismissed',
       'pull_request_review.edited',
-      'pull_request_review.submitted'
+      'pull_request_review.submitted',
+      'issue_comment.*'
     ]
     this.checkRunResult = new Map()
   }
@@ -126,10 +132,9 @@ class Checks extends Action {
 
   async afterValidate (context, settings, name, results) {
     const checkRunResult = this.checkRunResult.get(name)
+    const payload = settings.payload ? this.populatePayloadWithResult(settings.payload, results, context) : undefined
 
-    const payload = this.populatePayloadWithResult(settings.payload, results, context)
-
-    if (payload.text !== undefined) {
+    if (payload && payload.text !== undefined) {
       payload.text += MetaData.serialize({
         id: checkRunResult.data.id,
         eventName: context.eventName,

--- a/lib/actions/close.js
+++ b/lib/actions/close.js
@@ -6,6 +6,7 @@ class Close extends Action {
     this.supportedEvents = [
       'pull_request.*',
       'issues.*',
+      'issue_comment.*',
       'schedule.repository'
     ]
   }

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -29,6 +29,7 @@ class Comment extends Action {
     this.supportedEvents = [
       'pull_request.*',
       'issues.*',
+      'issue_comment.*',
       'schedule.repository'
     ]
   }

--- a/lib/actions/labels.js
+++ b/lib/actions/labels.js
@@ -23,6 +23,7 @@ class Labels extends Action {
     this.supportedEvents = [
       'pull_request.*',
       'issues.*',
+      'issue_comment.*',
       'schedule.repository'
     ]
   }

--- a/lib/configuration/transformers/v2Config.js
+++ b/lib/configuration/transformers/v2Config.js
@@ -33,7 +33,9 @@ const checkAndSetDefault = (ruleSet, defaultValue) => {
 
 const setPullRequestDefault = (config) => {
   config.mergeable.forEach((recipe) => {
-    if (recipe.when.includes('pull_request')) {
+    if (recipe.when.includes('pull_request') ||
+        recipe.when.includes('pull_request_review') ||
+        recipe.when.includes('issue_comment')) {
       if (!checkIfDefaultShouldBeApplied(recipe)) {
         if (recipe.pass === undefined) {
           recipe.pass = []


### PR DESCRIPTION
This is intended to be used with lastComment validator, e.g.
```yaml
version: 2
mergeable:
  - when: issue_comment.*
    validate:
      - do: lastComment
        must_include:
          regex: ^test$
    pass:
      - do: checks
        status: 'success'
      - do: assign
        assignees: ['@author']
      - do: comment
        payload:
          body: >
            @author assigned!
      # - do: close
      # - do: merge
      #   merge_method: 'squash'
    fail:
      - do: checks
        status: 'failure'
```