### PR TITLE
fix: Comments on Issues should not trigger 'checks' action

### DIFF
--- a/__fixtures__/unit/helper.js
+++ b/__fixtures__/unit/helper.js
@@ -64,7 +64,8 @@ module.exports = {
           user: {
             login: 'creator'
           },
-          number: (options.number) ? options.number : 1
+          number: (options.number) ? options.number : 1,
+          pull_request: {}
         }
       },
       log: {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =====================================
+| June 20, 2024: fix: Comments on Issues should not trigger `checks` action `#759 <https://github.com/mergeability/mergeable/pull/759>`_
 | June 12, 2024: feat: Support `issue_comment` event as trigger for actions `#754 <https://github.com/mergeability/mergeable/pull/754>`_
 | June 10, 2024: fix: Docker image not working `#753 <https://github.com/mergeability/mergeable/pull/753>`_
 | June 10, 2024: feat: publish multi arch docker image to dockerhub `#751 <https://github.com/mergeability/mergeable/pull/751>`_

--- a/lib/actions/checks.js
+++ b/lib/actions/checks.js
@@ -12,9 +12,9 @@ const createChecks = async (context, payload, actionObj) => {
   // Note: octokit (wrapped by probot) requires head_branch.
   // Contradicting API docs that only requires head_sha
   // --> https://developer.github.com/v3/checks/runs/#create-a-check-run
-  if (context.payload.checksuite) {
-    params.head_branch = context.payload.checksuite.head_branch
-    params.head_sha = context.payload.checksuite.head_sha
+  if (context.payload.check_suite) {
+    params.head_branch = context.payload.check_suite.head_branch
+    params.head_sha = context.payload.check_suite.head_sha
   } else if (context.eventName === 'issue_comment') {
     const issueNumber = context.payload.issue.number
     const pullRequest = (await actionObj.githubAPI.getPR(context, issueNumber)).data
@@ -104,6 +104,9 @@ class Checks extends Action {
   }
 
   async beforeValidate (context, settings, name) {
+    if (context.eventName === 'issue_comment' && !context.payload.issue?.pull_request) {
+      return Promise.resolve()
+    }
     const result = await createChecks(context, {
       status: 'in_progress',
       output: {
@@ -127,10 +130,16 @@ class Checks extends Action {
   }
 
   async run ({ context, settings, payload }) {
+    if (context.eventName === 'issue_comment' && !context.payload.issue?.pull_request) {
+      return Promise.resolve()
+    }
     await createChecks(context, payload, this)
   }
 
   async afterValidate (context, settings, name, results) {
+    if (context.eventName === 'issue_comment' && !context.payload.issue?.pull_request) {
+      return Promise.resolve()
+    }
     const checkRunResult = this.checkRunResult.get(name)
     const payload = settings.payload ? this.populatePayloadWithResult(settings.payload, results, context) : undefined
 

--- a/lib/actions/merge.js
+++ b/lib/actions/merge.js
@@ -44,6 +44,9 @@ class Merge extends Action {
   async beforeValidate () {}
 
   async afterValidate (context, settings, name, results) {
+    if (context.eventName === 'issue_comment' && !context.payload.issue?.pull_request) {
+      return Promise.resolve()
+    }
     if (settings.merge_method && !MERGE_METHOD_OPTIONS.includes(settings.merge_method)) {
       throw new UnSupportedSettingError(`Unknown Merge method, supported options are ${MERGE_METHOD_OPTIONS.join(', ')}`)
     }


### PR DESCRIPTION
Unfortunately #754 introduced a bug where could mergeable error when issue_comment event included a checks action and a comment is created on an Issue instead of an PR.