### PR TITLE
feat: Cache key uses repo.org only if USE_CONFIG_FROM_PULL_REQUEST is disabled.

### DIFF
--- a/__tests__/unit/configuration/configuration.test.js
+++ b/__tests__/unit/configuration/configuration.test.js
@@ -762,6 +762,10 @@ describe('with version 1', () => {
     config = await Configuration.fetchConfigFile(context)
     expect(config.mergeable.length).toEqual(1)
     expect(config.mergeable[0].name).toBe('repository rules')
+
+    // Clean-up the cache state after test
+    const configCache = Configuration.getCache()
+    await configCache.reset()
   })
 
   test('check config cache uses only owner as cache key if only global config can be fetched', async () => {
@@ -785,7 +789,6 @@ describe('with version 1', () => {
     context.globalSettings.use_org_as_default_config = true
     const configCache = Configuration.getCache()
     const repo = context.repo()
-    // configCache.set(repo.owner, orgConfig)
     let keys = await configCache.keys()
     expect(keys.length).toEqual(0)
     context.eventName = 'push'
@@ -802,6 +805,9 @@ describe('with version 1', () => {
     await configCache.set(repo.owner, injectedConfig)
     config = await Configuration.fetchConfigFile(context)
     expect(config).toEqual(injectedConfig)
+
+    // Clean-up the cache state after test
+    await configCache.reset()
   })
 })
 

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -120,8 +120,10 @@ class Configuration {
     // using pull request configuration by default, this behaviour
     // can be controlled using USE_CONFIG_FROM_PULL_REQUEST environment variable
     let usePullRequestConfig = true
+    let cacheKey = `${repo.owner}/${repo.repo}`
     if (globalSettings.use_config_from_pull_request !== undefined && globalSettings.use_config_from_pull_request === false) {
       usePullRequestConfig = false
+      cacheKey = `${repo.owner}`
     }
     if (usePullRequestConfig && ['pull_request', 'pull_request_review'].includes(context.eventName)) {
       const payload = context.payload.pull_request
@@ -157,7 +159,7 @@ class Configuration {
 
     if (globalSettings.use_config_cache !== undefined && globalSettings.use_config_cache === true) {
       Configuration.resetCache(context)
-      config = await cacheManager.get(`${repo.owner}/${repo.repo}`)
+      config = await cacheManager.get(cacheKey)
       if (config) {
         return config
       }
@@ -181,7 +183,7 @@ class Configuration {
     }
 
     if (globalSettings.use_config_cache !== undefined && globalSettings.use_config_cache === true) {
-      cacheManager.set(`${repo.owner}/${repo.repo}`, config)
+      cacheManager.set(cacheKey, config)
     }
 
     return config

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -107,6 +107,12 @@ class Configuration {
     const repo = context.repo()
 
     if (repo.repo === '.github') {
+      // Only org cache needs to be deleted if use_config_from_pull_request is disabled
+      if (globalSettings.use_config_from_pull_request !== undefined && globalSettings.use_config_from_pull_request === false) {
+        cacheManager.del(repo.owner)
+        return
+      }
+
       const keys = await cacheManager.keys()
       keys.filter(key => key.startsWith(`${repo.owner}/`)).map(key => cacheManager.del(key))
     } else {


### PR DESCRIPTION
Change the cache key to repo.org if only global mergeable configuration can be used.

This logic applies only in a combination of
- USE_CONFIG_FROM_PULL_REQUEST = false
- USE_ORG_AS_DEFAULT_CONFIG = true
- USE_CONFIG_CACHE = true

Before this change, mergeable would already cache the org config for each repo, but would always use the org/repo cache key. Unfortunately if only global repository is used, this leads to a lot of cache misses if PRs are opened across many repositories within the organization.

In our case, the current behavior let to us being rate-limited by GitHub.